### PR TITLE
Fix Android NDK relocation for Python 3.13+

### DIFF
--- a/android/build.sh
+++ b/android/build.sh
@@ -192,6 +192,17 @@ fi
 if [ -z "${toolchain:-}" ] && [ -n "${NDK_HOME:-}" ]; then
     toolchain=$(echo "$NDK_HOME"/toolchains/llvm/prebuilt/*)
 fi
+# 3.13+: CPython's in-tree Android tooling auto-resolves the NDK under
+# $ANDROID_HOME/ndk/$cpython_ndk_version/ without ever exporting NDK_HOME,
+# so neither of the branches above fires. Walk that path so normalize sees
+# a non-empty build-time toolchain and the relocation block can substitute
+# on consumer hosts.
+if [ -z "${toolchain:-}" ] && [ -n "${ANDROID_HOME:-}" ] && [ -n "${cpython_ndk_version:-}" ]; then
+    candidate="$ANDROID_HOME/ndk/$cpython_ndk_version/toolchains/llvm/prebuilt"
+    if [ -d "$candidate" ]; then
+        toolchain=$(echo "$candidate"/*)
+    fi
+fi
 
 python3 "$script_dir/normalize_mobile_forge_install.py" "$PREFIX" \
     --ndk-toolchain "${toolchain:-}"

--- a/android/normalize_mobile_forge_install.py
+++ b/android/normalize_mobile_forge_install.py
@@ -107,10 +107,17 @@ def _mobile_forge_relocate_sysconfig():
     for _key, _value in tuple(build_time_vars.items()):
         if not isinstance(_value, str):
             continue
-        for _old_prefix in _install_prefixes:
-            _value = _value.replace(_old_prefix, _prefix)
+        # NDK substitution must run before install-prefix substitution: when
+        # the build-time NDK lives under one of `_install_prefixes` (e.g. the
+        # GitHub runner places NDK under `/usr/local/lib/android/sdk/ndk/...`),
+        # rewriting the prefix first would mangle the NDK string and leave
+        # nothing for the NDK rule to match. Swapping order keeps both rules
+        # independent: NDK fully resolves to the local toolchain, then any
+        # remaining install-prefix references get re-anchored.
         if _build_ndk and _local_ndk:
             _value = _value.replace(_build_ndk, _local_ndk)
+        for _old_prefix in _install_prefixes:
+            _value = _value.replace(_old_prefix, _prefix)
         build_time_vars[_key] = _value
 
 


### PR DESCRIPTION
## Summary

- **android/build.sh**: add a third `\$toolchain` fallback that walks `\$ANDROID_HOME/ndk/\$cpython_ndk_version/toolchains/llvm/prebuilt/*`. For 3.13+, CPython's in-tree Android tooling resolves the NDK there without ever exporting `NDK_HOME`, so neither of the existing fallbacks fires and `normalize_mobile_forge_install.py --ndk-toolchain ''` ends up baking `_build_ndk = ''` into the sysconfig.
- **android/normalize_mobile_forge_install.py**: reorder NDK substitution to run **before** install-prefix substitution. For 3.13+ the CI's NDK lives under `/usr/local/lib/android/sdk/ndk/...`, which is inside one of `_install_prefixes` — so the prefix rule was mangling the NDK path string before the NDK rule could match it.

## Symptom (3.13/3.14 on macOS)

```
forge android:arm64-v8a cryptography
ERROR: Cannot find cross-compiler ('<install>/lib/android/sdk/ndk/27.3.13750724/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang')!
```

The path points at `linux-x86_64` (binaries built and shipped for Linux only) on a Mac, where the right slot would be `darwin-x86_64`. After both fixes, the relocation block finds the user's local NDK (via `~/Library/Android/sdk/ndk/<ver>`, `NDK_HOME`, etc.) and rewrites CC/CXX/AR/STRIP/RANLIB to the matching `darwin-x86_64` toolchain.

## Why 3.12 was unaffected

3.12's build path sources `android-env.sh` (which sets `\$toolchain` directly) and the CI's NDK lives under `~/ndk/r27d/...`, which is **not** inside `_install_prefixes` — so neither bug fires for that version.

## Test plan

- [x] Verified the 3.13 / 3.14 sysconfig files on disk carry `_build_ndk = ''` and the resulting CC path with the wrong host slot
- [ ] Re-run the python-build CI on this branch and confirm 3.13 / 3.14 tarballs land with non-empty `_build_ndk` in the relocation block
- [ ] Download the new tarballs on macOS and confirm \`forge android:arm64-v8a <pkg>\` (Python 3.13 and 3.14) resolves CC to the local NDK's `darwin-x86_64` toolchain
- [ ] Confirm Python 3.12 builds still pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)