### PR TITLE
Fix 3.13.14 / 3.14.6 build failures

### DIFF
--- a/.github/workflows/build-python-version.yml
+++ b/.github/workflows/build-python-version.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ env.PYTHON_VERSION_SHORT }}
 
       - name: Run pre-build tests
         shell: bash
@@ -141,7 +141,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ env.PYTHON_VERSION_SHORT }}
 
       - working-directory: linux
         shell: bash

--- a/darwin/ios_patches/3.13/Python.patch
+++ b/darwin/ios_patches/3.13/Python.patch
@@ -6757,10 +6757,10 @@ index 1bb6a05dc11..49febd56a37 100755
  	none--*)
  		# None (no kernel, i.e. freestanding / bare metal),
 diff --git a/configure b/configure
-index 901a26c9602..508d01f1b7e 100755
+index 0df4751..cf32adf 100755
 --- a/configure
 +++ b/configure
-@@ -979,6 +979,10 @@
+@@ -979,6 +979,10 @@ LDFLAGS
  CFLAGS
  CC
  HAS_XCRUN
@@ -6771,7 +6771,7 @@ index 901a26c9602..508d01f1b7e 100755
  IPHONEOS_DEPLOYMENT_TARGET
  EXPORT_MACOSX_DEPLOYMENT_TARGET
  CONFIGURE_MACOSX_DEPLOYMENT_TARGET
-@@ -4058,6 +4062,15 @@
+@@ -4058,6 +4062,15 @@ then
  	*-apple-ios*)
  		ac_sys_system=iOS
  		;;
@@ -6787,7 +6787,7 @@ index 901a26c9602..508d01f1b7e 100755
  	*-*-vxworks*)
  	    ac_sys_system=VxWorks
  	    ;;
-@@ -4112,7 +4125,7 @@
+@@ -4112,7 +4125,7 @@ printf "%s\n" "\"$MACHDEP\"" >&6; }
  # On cross-compile builds, configure will look for a host-specific compiler by
  # prepending the user-provided host triple to the required binary name.
  #
@@ -6796,7 +6796,7 @@ index 901a26c9602..508d01f1b7e 100755
  # which isn't a binary that exists, and isn't very convenient, as it contains the
  # iOS version. As the default cross-compiler name won't exist, configure falls
  # back to gcc, which *definitely* won't work. We're providing wrapper scripts for
-@@ -4127,6 +4140,17 @@
+@@ -4127,6 +4140,17 @@ if test -z "$AR"; then
  		aarch64-apple-ios*-simulator) AR=arm64-apple-ios-simulator-ar ;;
  		aarch64-apple-ios*)           AR=arm64-apple-ios-ar ;;
  		x86_64-apple-ios*-simulator)  AR=x86_64-apple-ios-simulator-ar ;;
@@ -6814,7 +6814,7 @@ index 901a26c9602..508d01f1b7e 100755
  		*)
  	esac
  fi
-@@ -4135,6 +4159,17 @@
+@@ -4135,6 +4159,17 @@ if test -z "$CC"; then
  		aarch64-apple-ios*-simulator) CC=arm64-apple-ios-simulator-clang ;;
  		aarch64-apple-ios*)           CC=arm64-apple-ios-clang ;;
  		x86_64-apple-ios*-simulator)  CC=x86_64-apple-ios-simulator-clang ;;
@@ -6832,7 +6832,7 @@ index 901a26c9602..508d01f1b7e 100755
  		*)
  	esac
  fi
-@@ -4143,6 +4178,17 @@
+@@ -4143,6 +4178,17 @@ if test -z "$CPP"; then
  		aarch64-apple-ios*-simulator) CPP=arm64-apple-ios-simulator-cpp ;;
  		aarch64-apple-ios*)           CPP=arm64-apple-ios-cpp ;;
  		x86_64-apple-ios*-simulator)  CPP=x86_64-apple-ios-simulator-cpp ;;
@@ -6850,7 +6850,7 @@ index 901a26c9602..508d01f1b7e 100755
  		*)
  	esac
  fi
-@@ -4151,6 +4197,17 @@
+@@ -4151,6 +4197,17 @@ if test -z "$CXX"; then
  		aarch64-apple-ios*-simulator) CXX=arm64-apple-ios-simulator-clang++ ;;
  		aarch64-apple-ios*)           CXX=arm64-apple-ios-clang++ ;;
  		x86_64-apple-ios*-simulator)  CXX=x86_64-apple-ios-simulator-clang++ ;;
@@ -6868,7 +6868,7 @@ index 901a26c9602..508d01f1b7e 100755
  		*)
  	esac
  fi
-@@ -4271,8 +4328,11 @@
+@@ -4271,8 +4328,11 @@ then :
  	case $enableval in
  	yes)
  		case $ac_sys_system in
@@ -6882,7 +6882,7 @@ index 901a26c9602..508d01f1b7e 100755
  			*) as_fn_error $? "Unknown platform for framework build" "$LINENO" 5
  		esac
  	esac
-@@ -4281,6 +4341,9 @@
+@@ -4281,6 +4341,9 @@ then :
  	no)
  		case $ac_sys_system in
  			iOS) as_fn_error $? "iOS builds must use --enable-framework" "$LINENO" 5 ;;
@@ -6892,7 +6892,7 @@ index 901a26c9602..508d01f1b7e 100755
  			*)
  				PYTHONFRAMEWORK=
  				PYTHONFRAMEWORKDIR=no-framework
-@@ -4383,9 +4446,54 @@
+@@ -4383,9 +4446,54 @@ then :
  
  				prefix=$PYTHONFRAMEWORKPREFIX
  				PYTHONFRAMEWORKINSTALLNAMEPREFIX="@rpath/$PYTHONFRAMEWORKDIR"
@@ -6949,7 +6949,7 @@ index 901a26c9602..508d01f1b7e 100755
  
  				;;
  			*)
-@@ -4398,6 +4506,9 @@
+@@ -4398,6 +4506,9 @@ else $as_nop
  
  	case $ac_sys_system in
  		iOS) as_fn_error $? "iOS builds must use --enable-framework" "$LINENO" 5 ;;
@@ -6959,7 +6959,7 @@ index 901a26c9602..508d01f1b7e 100755
  		*)
  			PYTHONFRAMEWORK=
  			PYTHONFRAMEWORKDIR=no-framework
-@@ -4451,8 +4562,8 @@
+@@ -4451,8 +4562,8 @@ then :
      case "$withval" in
      yes)
        case $ac_sys_system in
@@ -6970,7 +6970,7 @@ index 901a26c9602..508d01f1b7e 100755
            APP_STORE_COMPLIANCE_PATCH="Mac/Resources/app-store-compliance.patch"
            ;;
          *) as_fn_error $? "no default app store compliance patch available for $ac_sys_system" "$LINENO" 5 ;;
-@@ -4470,8 +4581,8 @@
+@@ -4470,8 +4581,8 @@ printf "%s\n" "applying custom app store compliance patch" >&6; }
  else $as_nop
  
      case $ac_sys_system in
@@ -6981,7 +6981,7 @@ index 901a26c9602..508d01f1b7e 100755
          APP_STORE_COMPLIANCE_PATCH="Mac/Resources/app-store-compliance.patch"
          { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: applying default app store compliance patch" >&5
  printf "%s\n" "applying default app store compliance patch" >&6; }
-@@ -4488,6 +4599,8 @@
+@@ -4488,6 +4599,8 @@ fi
  
  
  
@@ -6990,7 +6990,7 @@ index 901a26c9602..508d01f1b7e 100755
  
  if test "$cross_compiling" = yes; then
  	case "$host" in
-@@ -4525,6 +4638,78 @@
+@@ -4525,6 +4638,78 @@ printf "%s\n" "$IPHONEOS_DEPLOYMENT_TARGET" >&6; }
  				;;
  		esac
  		;;
@@ -7069,7 +7069,7 @@ index 901a26c9602..508d01f1b7e 100755
  	*-*-vxworks*)
  		_host_ident=$host_cpu
  		;;
-@@ -4603,9 +4788,15 @@
+@@ -4603,9 +4788,15 @@ printf "%s\n" "#define _BSD_SOURCE 1" >>confdefs.h
      define_xopen_source=no;;
    Darwin/[12][0-9].*)
      define_xopen_source=no;;
@@ -7086,7 +7086,7 @@ index 901a26c9602..508d01f1b7e 100755
    # On QNX 6.3.2, defining _XOPEN_SOURCE prevents netdb.h from
    # defining NI_NUMERICHOST.
    QNX/6.3.2)
-@@ -4668,7 +4859,14 @@
+@@ -4668,7 +4859,14 @@ fi
  CONFIGURE_MACOSX_DEPLOYMENT_TARGET=
  EXPORT_MACOSX_DEPLOYMENT_TARGET='#'
  
@@ -7102,7 +7102,7 @@ index 901a26c9602..508d01f1b7e 100755
  
  
  # checks for alternative programs
-@@ -4709,6 +4907,16 @@
+@@ -4709,6 +4907,16 @@ case $ac_sys_system in #(
      as_fn_append CFLAGS " -mios-version-min=${IPHONEOS_DEPLOYMENT_TARGET}"
      as_fn_append LDFLAGS " -mios-version-min=${IPHONEOS_DEPLOYMENT_TARGET}"
     ;; #(
@@ -7119,7 +7119,7 @@ index 901a26c9602..508d01f1b7e 100755
    *) :
       ;;
  esac
-@@ -7010,6 +7218,12 @@
+@@ -7010,6 +7218,12 @@ case $ac_sys_system in #(
      MULTIARCH="" ;; #(
    iOS) :
      MULTIARCH="" ;; #(
@@ -7132,7 +7132,7 @@ index 901a26c9602..508d01f1b7e 100755
    FreeBSD*) :
      MULTIARCH="" ;; #(
    *) :
-@@ -7030,7 +7244,7 @@
+@@ -7030,7 +7244,7 @@ fi
  printf "%s\n" "$MULTIARCH" >&6; }
  
  case $ac_sys_system in #(
@@ -7141,7 +7141,7 @@ index 901a26c9602..508d01f1b7e 100755
      SOABI_PLATFORM=`echo "$PLATFORM_TRIPLET" | cut -d '-' -f2` ;; #(
    *) :
      SOABI_PLATFORM=$PLATFORM_TRIPLET
-@@ -7081,6 +7295,18 @@
+@@ -7081,6 +7295,18 @@ case $host/$ac_cv_cc_name in #(
      PY_SUPPORT_TIER=3 ;; #(
      aarch64-apple-ios*/clang) :
      PY_SUPPORT_TIER=3 ;; #(
@@ -7160,7 +7160,7 @@ index 901a26c9602..508d01f1b7e 100755
      aarch64-*-linux-android/clang) :
      PY_SUPPORT_TIER=3 ;; #(
      x86_64-*-linux-android/clang) :
-@@ -7554,7 +7780,7 @@
+@@ -7554,7 +7780,7 @@ then
    case $ac_sys_system in
      Darwin)
        LDLIBRARY='$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)';;
@@ -7169,7 +7169,7 @@ index 901a26c9602..508d01f1b7e 100755
        LDLIBRARY='$(PYTHONFRAMEWORKDIR)/$(PYTHONFRAMEWORK)';;
      *)
        as_fn_error $? "Unknown platform for framework build" "$LINENO" 5;;
-@@ -7620,7 +7846,7 @@
+@@ -7620,7 +7846,7 @@ printf "%s\n" "#define Py_ENABLE_SHARED 1" >>confdefs.h
        BLDLIBRARY='-L. -lpython$(LDVERSION)'
        RUNSHARED=DYLD_LIBRARY_PATH=`pwd`${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}
        ;;
@@ -7178,7 +7178,7 @@ index 901a26c9602..508d01f1b7e 100755
        LDLIBRARY='libpython$(LDVERSION).dylib'
        ;;
      AIX*)
-@@ -12975,7 +13201,7 @@
+@@ -13063,7 +13289,7 @@ then
  			BLDSHARED="$LDSHARED"
  		fi
  		;;
@@ -7187,7 +7187,7 @@ index 901a26c9602..508d01f1b7e 100755
  		LDSHARED='$(CC) -dynamiclib -F . -framework $(PYTHONFRAMEWORK)'
  		LDCXXSHARED='$(CXX) -dynamiclib -F . -framework $(PYTHONFRAMEWORK)'
  		BLDSHARED="$LDSHARED"
-@@ -13108,7 +13334,7 @@
+@@ -13196,7 +13422,7 @@ then
  	Linux-android*) LINKFORSHARED="-pie -Xlinker -export-dynamic";;
  	Linux*|GNU*) LINKFORSHARED="-Xlinker -export-dynamic";;
  	# -u libsys_s pulls in all symbols in libsys
@@ -7196,7 +7196,7 @@ index 901a26c9602..508d01f1b7e 100755
  		LINKFORSHARED="$extra_undefs -framework CoreFoundation"
  
  		# Issue #18075: the default maximum stack size (8MBytes) is too
-@@ -13132,7 +13358,7 @@
+@@ -13220,7 +13446,7 @@ printf "%s\n" "#define THREAD_STACK_SIZE 0x$stack_size" >>confdefs.h
  				LINKFORSHARED="$LINKFORSHARED "'$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
  			fi
  			LINKFORSHARED="$LINKFORSHARED"
@@ -7205,7 +7205,7 @@ index 901a26c9602..508d01f1b7e 100755
  			LINKFORSHARED="-Wl,-stack_size,$stack_size $LINKFORSHARED "'$(PYTHONFRAMEWORKDIR)/$(PYTHONFRAMEWORK)'
  		fi
  		;;
-@@ -14728,7 +14954,7 @@
+@@ -14816,7 +15042,7 @@ then :
  
              ctypes_malloc_closure=yes
       ;; #(
@@ -7214,9 +7214,9 @@ index 901a26c9602..508d01f1b7e 100755
  
        ctypes_malloc_closure=yes
       ;; #(
-@@ -18197,12 +18423,6 @@
+@@ -18279,12 +18505,6 @@ if test "x$ac_cv_func_dup" = xyes
  then :
-   printf "%s\n" "#define HAVE_DUP3 1" >>confdefs.h
+   printf "%s\n" "#define HAVE_DUP 1" >>confdefs.h
  
 -fi
 -ac_fn_c_check_func "$LINENO" "execv" "ac_cv_func_execv"
@@ -7227,7 +7227,7 @@ index 901a26c9602..508d01f1b7e 100755
  fi
  ac_fn_c_check_func "$LINENO" "explicit_bzero" "ac_cv_func_explicit_bzero"
  if test "x$ac_cv_func_explicit_bzero" = xyes
-@@ -18263,18 +18483,6 @@
+@@ -18345,18 +18565,6 @@ if test "x$ac_cv_func_fexecve" = xyes
  then :
    printf "%s\n" "#define HAVE_FEXECVE 1" >>confdefs.h
  
@@ -7246,7 +7246,7 @@ index 901a26c9602..508d01f1b7e 100755
  fi
  ac_fn_c_check_func "$LINENO" "fpathconf" "ac_cv_func_fpathconf"
  if test "x$ac_cv_func_fpathconf" = xyes
-@@ -18707,24 +18915,6 @@
+@@ -18783,24 +18991,6 @@ if test "x$ac_cv_func_posix_openpt" = xyes
  then :
    printf "%s\n" "#define HAVE_POSIX_OPENPT 1" >>confdefs.h
  
@@ -7271,7 +7271,7 @@ index 901a26c9602..508d01f1b7e 100755
  fi
  ac_fn_c_check_func "$LINENO" "pread" "ac_cv_func_pread"
  if test "x$ac_cv_func_pread" = xyes
-@@ -19013,12 +19203,6 @@
+@@ -19089,12 +19279,6 @@ if test "x$ac_cv_func_sigaction" = xyes
  then :
    printf "%s\n" "#define HAVE_SIGACTION 1" >>confdefs.h
  
@@ -7284,7 +7284,7 @@ index 901a26c9602..508d01f1b7e 100755
  fi
  ac_fn_c_check_func "$LINENO" "sigfillset" "ac_cv_func_sigfillset"
  if test "x$ac_cv_func_sigfillset" = xyes
-@@ -19287,11 +19471,11 @@
+@@ -19363,11 +19547,11 @@ fi
  
  fi
  
@@ -7295,10 +7295,10 @@ index 901a26c9602..508d01f1b7e 100755
  # raise an error if used at runtime. Force these symbols off.
 -if test "$ac_sys_system" != "iOS" ; then
 +if test "$ac_sys_system" != "iOS" -a "$ac_sys_system" != "tvOS" -a "$ac_sys_system" != "visionOS" -a "$ac_sys_system" != "watchOS" ; then
-   ac_fn_c_check_func "$LINENO" "getentropy" "ac_cv_func_getentropy"
- if test "x$ac_cv_func_getentropy" = xyes
+   ac_fn_c_check_func "$LINENO" "dup3" "ac_cv_func_dup3"
+ if test "x$ac_cv_func_dup3" = xyes
  then :
-@@ -19313,6 +19497,53 @@
+@@ -19401,6 +19585,53 @@ fi
  
  fi
  
@@ -7352,7 +7352,7 @@ index 901a26c9602..508d01f1b7e 100755
  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC options needed to detect all undeclared functions" >&5
  printf %s "checking for $CC options needed to detect all undeclared functions... " >&6; }
  if test ${ac_cv_c_undeclared_builtin_options+y}
-@@ -22135,7 +22366,8 @@
+@@ -22223,7 +22454,8 @@ fi
  
  
  # check for openpty, login_tty, and forkpty
@@ -7362,7 +7362,7 @@ index 901a26c9602..508d01f1b7e 100755
  
    for ac_func in openpty
  do :
-@@ -22231,7 +22463,7 @@
+@@ -22319,7 +22551,7 @@ fi
  fi
  
  done
@@ -7371,7 +7371,7 @@ index 901a26c9602..508d01f1b7e 100755
  printf %s "checking for library containing login_tty... " >&6; }
  if test ${ac_cv_search_login_tty+y}
  then :
-@@ -22388,6 +22620,7 @@
+@@ -22476,6 +22708,7 @@ fi
  fi
  
  done
@@ -7379,7 +7379,7 @@ index 901a26c9602..508d01f1b7e 100755
  
  # check for long file support functions
  ac_fn_c_check_func "$LINENO" "fseek64" "ac_cv_func_fseek64"
-@@ -22634,10 +22867,10 @@
+@@ -22722,10 +22955,10 @@ fi
  
  done
  
@@ -7392,7 +7392,7 @@ index 901a26c9602..508d01f1b7e 100755
  then
  
    for ac_func in clock_settime
-@@ -22923,7 +23156,7 @@
+@@ -23011,7 +23244,7 @@ else $as_nop
    if test "$cross_compiling" = yes
  then :
  
@@ -7401,7 +7401,7 @@ index 901a26c9602..508d01f1b7e 100755
    ac_cv_buggy_getaddrinfo="no"
  elif test "${enable_ipv6+set}" = set; then
    ac_cv_buggy_getaddrinfo="no -- configured with --(en|dis)able-ipv6"
-@@ -24869,8 +25102,8 @@
+@@ -24957,8 +25190,8 @@ if test "$PY_ENABLE_SHARED" = "1" && ( test -n "$ANDROID_API_LEVEL" || test "$MA
    LIBPYTHON="\$(BLDLIBRARY)"
  fi
  
@@ -7412,7 +7412,7 @@ index 901a26c9602..508d01f1b7e 100755
    MODULE_DEPS_SHARED="$MODULE_DEPS_SHARED \$(PYTHONFRAMEWORKDIR)/\$(PYTHONFRAMEWORK)"
  fi
  
-@@ -27518,7 +27751,7 @@
+@@ -27606,7 +27839,7 @@ LIBS=$save_LIBS
  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for device files" >&5
  printf "%s\n" "$as_me: checking for device files" >&6;}
  
@@ -7421,7 +7421,7 @@ index 901a26c9602..508d01f1b7e 100755
    ac_cv_file__dev_ptmx=no
    ac_cv_file__dev_ptc=no
  else
-@@ -27951,7 +28184,7 @@
+@@ -28039,7 +28272,7 @@ else $as_nop
      with_ensurepip=no ;; #(
    WASI) :
      with_ensurepip=no ;; #(
@@ -7430,7 +7430,7 @@ index 901a26c9602..508d01f1b7e 100755
      with_ensurepip=no ;; #(
    *) :
      with_ensurepip=upgrade
-@@ -28970,7 +29203,7 @@
+@@ -29058,7 +29291,7 @@ case $ac_sys_system in #(
   ;; #(
      Darwin) :
       ;; #(
@@ -7439,7 +7439,7 @@ index 901a26c9602..508d01f1b7e 100755
  
  
  
-@@ -32734,7 +32967,10 @@
+@@ -32822,7 +33055,10 @@ do
      "Mac/PythonLauncher/Makefile") CONFIG_FILES="$CONFIG_FILES Mac/PythonLauncher/Makefile" ;;
      "Mac/Resources/framework/Info.plist") CONFIG_FILES="$CONFIG_FILES Mac/Resources/framework/Info.plist" ;;
      "Mac/Resources/app/Info.plist") CONFIG_FILES="$CONFIG_FILES Mac/Resources/app/Info.plist" ;;
@@ -7452,10 +7452,10 @@ index 901a26c9602..508d01f1b7e 100755
      "Misc/python.pc") CONFIG_FILES="$CONFIG_FILES Misc/python.pc" ;;
      "Misc/python-embed.pc") CONFIG_FILES="$CONFIG_FILES Misc/python-embed.pc" ;;
 diff --git a/configure.ac b/configure.ac
-index 597a44b331a..5109db2f48f 100644
+index a016a43..698553b 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -330,6 +330,15 @@
+@@ -330,6 +330,15 @@ then
  	*-apple-ios*)
  		ac_sys_system=iOS
  		;;
@@ -7471,7 +7471,7 @@ index 597a44b331a..5109db2f48f 100644
  	*-*-vxworks*)
  	    ac_sys_system=VxWorks
  	    ;;
-@@ -382,7 +391,7 @@
+@@ -382,7 +391,7 @@ AC_MSG_RESULT(["$MACHDEP"])
  # On cross-compile builds, configure will look for a host-specific compiler by
  # prepending the user-provided host triple to the required binary name.
  #
@@ -7480,7 +7480,7 @@ index 597a44b331a..5109db2f48f 100644
  # which isn't a binary that exists, and isn't very convenient, as it contains the
  # iOS version. As the default cross-compiler name won't exist, configure falls
  # back to gcc, which *definitely* won't work. We're providing wrapper scripts for
-@@ -397,6 +406,17 @@
+@@ -397,6 +406,17 @@ if test -z "$AR"; then
  		aarch64-apple-ios*-simulator) AR=arm64-apple-ios-simulator-ar ;;
  		aarch64-apple-ios*)           AR=arm64-apple-ios-ar ;;
  		x86_64-apple-ios*-simulator)  AR=x86_64-apple-ios-simulator-ar ;;
@@ -7498,7 +7498,7 @@ index 597a44b331a..5109db2f48f 100644
  		*)
  	esac
  fi
-@@ -405,6 +425,17 @@
+@@ -405,6 +425,17 @@ if test -z "$CC"; then
  		aarch64-apple-ios*-simulator) CC=arm64-apple-ios-simulator-clang ;;
  		aarch64-apple-ios*)           CC=arm64-apple-ios-clang ;;
  		x86_64-apple-ios*-simulator)  CC=x86_64-apple-ios-simulator-clang ;;
@@ -7516,7 +7516,7 @@ index 597a44b331a..5109db2f48f 100644
  		*)
  	esac
  fi
-@@ -413,6 +444,17 @@
+@@ -413,6 +444,17 @@ if test -z "$CPP"; then
  		aarch64-apple-ios*-simulator) CPP=arm64-apple-ios-simulator-cpp ;;
  		aarch64-apple-ios*)           CPP=arm64-apple-ios-cpp ;;
  		x86_64-apple-ios*-simulator)  CPP=x86_64-apple-ios-simulator-cpp ;;
@@ -7534,7 +7534,7 @@ index 597a44b331a..5109db2f48f 100644
  		*)
  	esac
  fi
-@@ -421,6 +463,17 @@
+@@ -421,6 +463,17 @@ if test -z "$CXX"; then
  		aarch64-apple-ios*-simulator) CXX=arm64-apple-ios-simulator-clang++ ;;
  		aarch64-apple-ios*)           CXX=arm64-apple-ios-clang++ ;;
  		x86_64-apple-ios*-simulator)  CXX=x86_64-apple-ios-simulator-clang++ ;;
@@ -7552,7 +7552,7 @@ index 597a44b331a..5109db2f48f 100644
  		*)
  	esac
  fi
-@@ -535,8 +588,11 @@
+@@ -535,8 +588,11 @@ AC_ARG_ENABLE([framework],
  	case $enableval in
  	yes)
  		case $ac_sys_system in
@@ -7566,7 +7566,7 @@ index 597a44b331a..5109db2f48f 100644
  			*) AC_MSG_ERROR([Unknown platform for framework build])
  		esac
  	esac
-@@ -545,6 +601,9 @@
+@@ -545,6 +601,9 @@ AC_ARG_ENABLE([framework],
  	no)
  		case $ac_sys_system in
  			iOS) AC_MSG_ERROR([iOS builds must use --enable-framework]) ;;
@@ -7576,7 +7576,7 @@ index 597a44b331a..5109db2f48f 100644
  			*)
  				PYTHONFRAMEWORK=
  				PYTHONFRAMEWORKDIR=no-framework
-@@ -643,9 +702,51 @@
+@@ -643,9 +702,51 @@ AC_ARG_ENABLE([framework],
  
  				prefix=$PYTHONFRAMEWORKPREFIX
  				PYTHONFRAMEWORKINSTALLNAMEPREFIX="@rpath/$PYTHONFRAMEWORKDIR"
@@ -7630,7 +7630,7 @@ index 597a44b331a..5109db2f48f 100644
  				;;
  			*)
  				AC_MSG_ERROR([Unknown platform for framework build])
-@@ -655,6 +756,9 @@
+@@ -655,6 +756,9 @@ AC_ARG_ENABLE([framework],
  	],[
  	case $ac_sys_system in
  		iOS) AC_MSG_ERROR([iOS builds must use --enable-framework]) ;;
@@ -7640,7 +7640,7 @@ index 597a44b331a..5109db2f48f 100644
  		*)
  			PYTHONFRAMEWORK=
  			PYTHONFRAMEWORKDIR=no-framework
-@@ -707,8 +811,8 @@
+@@ -707,8 +811,8 @@ AC_ARG_WITH(
      case "$withval" in
      yes)
        case $ac_sys_system in
@@ -7651,7 +7651,7 @@ index 597a44b331a..5109db2f48f 100644
            APP_STORE_COMPLIANCE_PATCH="Mac/Resources/app-store-compliance.patch"
            ;;
          *) AC_MSG_ERROR([no default app store compliance patch available for $ac_sys_system]) ;;
-@@ -722,8 +826,8 @@
+@@ -722,8 +826,8 @@ AC_ARG_WITH(
      esac
    ],[
      case $ac_sys_system in
@@ -7662,7 +7662,7 @@ index 597a44b331a..5109db2f48f 100644
          APP_STORE_COMPLIANCE_PATCH="Mac/Resources/app-store-compliance.patch"
          AC_MSG_RESULT([applying default app store compliance patch])
          ;;
-@@ -736,6 +840,8 @@
+@@ -736,6 +840,8 @@ AC_ARG_WITH(
  ])
  AC_SUBST([APP_STORE_COMPLIANCE_PATCH])
  
@@ -7671,7 +7671,7 @@ index 597a44b331a..5109db2f48f 100644
  AC_SUBST([_PYTHON_HOST_PLATFORM])
  if test "$cross_compiling" = yes; then
  	case "$host" in
-@@ -771,6 +877,70 @@
+@@ -771,6 +877,70 @@ if test "$cross_compiling" = yes; then
  				;;
  		esac
  		;;
@@ -7742,7 +7742,7 @@ index 597a44b331a..5109db2f48f 100644
  	*-*-vxworks*)
  		_host_ident=$host_cpu
  		;;
-@@ -848,9 +1018,15 @@
+@@ -848,9 +1018,15 @@ case $ac_sys_system/$ac_sys_release in
      define_xopen_source=no;;
    Darwin/@<:@[12]@:>@@<:@0-9@:>@.*)
      define_xopen_source=no;;
@@ -7759,7 +7759,7 @@ index 597a44b331a..5109db2f48f 100644
    # On QNX 6.3.2, defining _XOPEN_SOURCE prevents netdb.h from
    # defining NI_NUMERICHOST.
    QNX/6.3.2)
-@@ -909,8 +1085,15 @@
+@@ -909,8 +1085,15 @@ AC_SUBST([EXPORT_MACOSX_DEPLOYMENT_TARGET])
  CONFIGURE_MACOSX_DEPLOYMENT_TARGET=
  EXPORT_MACOSX_DEPLOYMENT_TARGET='#'
  
@@ -7776,7 +7776,7 @@ index 597a44b331a..5109db2f48f 100644
  
  # checks for alternative programs
  
-@@ -944,11 +1127,19 @@
+@@ -944,11 +1127,19 @@ AS_CASE([$host],
    ],
  )
  
@@ -7797,7 +7797,7 @@ index 597a44b331a..5109db2f48f 100644
    ],
  )
  
-@@ -1136,6 +1327,9 @@
+@@ -1136,6 +1327,9 @@ AC_MSG_CHECKING([for multiarch])
  AS_CASE([$ac_sys_system],
    [Darwin*], [MULTIARCH=""],
    [iOS], [MULTIARCH=""],
@@ -7807,7 +7807,7 @@ index 597a44b331a..5109db2f48f 100644
    [FreeBSD*], [MULTIARCH=""],
    [MULTIARCH=$($CC --print-multiarch 2>/dev/null)]
  )
-@@ -1157,7 +1351,7 @@
+@@ -1157,7 +1351,7 @@ dnl will have multiple sysconfig modules (one for each CPU architecture), but
  dnl use a single "fat" binary at runtime. SOABI_PLATFORM is the component of
  dnl the PLATFORM_TRIPLET that will be used in binary module extensions.
  AS_CASE([$ac_sys_system],
@@ -7816,7 +7816,7 @@ index 597a44b331a..5109db2f48f 100644
    [SOABI_PLATFORM=$PLATFORM_TRIPLET]
  )
  
-@@ -1184,15 +1378,21 @@
+@@ -1184,15 +1378,21 @@ AS_CASE([$host/$ac_cv_cc_name],
    [wasm32-unknown-wasip1/clang],     [PY_SUPPORT_TIER=2], dnl WebAssembly System Interface preview1, clang
    [x86_64-*-linux-gnu/clang],        [PY_SUPPORT_TIER=2], dnl Linux on AMD64, any vendor, glibc, clang
  
@@ -7847,7 +7847,7 @@ index 597a44b331a..5109db2f48f 100644
  
    [PY_SUPPORT_TIER=0]
  )
-@@ -1525,7 +1725,7 @@
+@@ -1525,7 +1725,7 @@ then
    case $ac_sys_system in
      Darwin)
        LDLIBRARY='$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)';;
@@ -7856,7 +7856,7 @@ index 597a44b331a..5109db2f48f 100644
        LDLIBRARY='$(PYTHONFRAMEWORKDIR)/$(PYTHONFRAMEWORK)';;
      *)
        AC_MSG_ERROR([Unknown platform for framework build]);;
-@@ -1590,7 +1790,7 @@
+@@ -1590,7 +1790,7 @@ if test $enable_shared = "yes"; then
        BLDLIBRARY='-L. -lpython$(LDVERSION)'
        RUNSHARED=DYLD_LIBRARY_PATH=`pwd`${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}
        ;;
@@ -7865,7 +7865,7 @@ index 597a44b331a..5109db2f48f 100644
        LDLIBRARY='libpython$(LDVERSION).dylib'
        ;;
      AIX*)
-@@ -3486,7 +3686,7 @@
+@@ -3511,7 +3711,7 @@ then
  			BLDSHARED="$LDSHARED"
  		fi
  		;;
@@ -7874,7 +7874,7 @@ index 597a44b331a..5109db2f48f 100644
  		LDSHARED='$(CC) -dynamiclib -F . -framework $(PYTHONFRAMEWORK)'
  		LDCXXSHARED='$(CXX) -dynamiclib -F . -framework $(PYTHONFRAMEWORK)'
  		BLDSHARED="$LDSHARED"
-@@ -3610,7 +3810,7 @@
+@@ -3635,7 +3835,7 @@ then
  	Linux-android*) LINKFORSHARED="-pie -Xlinker -export-dynamic";;
  	Linux*|GNU*) LINKFORSHARED="-Xlinker -export-dynamic";;
  	# -u libsys_s pulls in all symbols in libsys
@@ -7883,7 +7883,7 @@ index 597a44b331a..5109db2f48f 100644
  		LINKFORSHARED="$extra_undefs -framework CoreFoundation"
  
  		# Issue #18075: the default maximum stack size (8MBytes) is too
-@@ -3634,7 +3834,7 @@
+@@ -3659,7 +3859,7 @@ then
  				LINKFORSHARED="$LINKFORSHARED "'$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
  			fi
  			LINKFORSHARED="$LINKFORSHARED"
@@ -7892,7 +7892,7 @@ index 597a44b331a..5109db2f48f 100644
  			LINKFORSHARED="-Wl,-stack_size,$stack_size $LINKFORSHARED "'$(PYTHONFRAMEWORKDIR)/$(PYTHONFRAMEWORK)'
  		fi
  		;;
-@@ -4106,7 +4306,7 @@
+@@ -4131,7 +4331,7 @@ AS_VAR_IF([have_libffi], [yes], [
        dnl when do we need USING_APPLE_OS_LIBFFI?
        ctypes_malloc_closure=yes
      ],
@@ -7901,25 +7901,25 @@ index 597a44b331a..5109db2f48f 100644
        ctypes_malloc_closure=yes
      ],
      [sunos5], [AS_VAR_APPEND([LIBFFI_LIBS], [" -mimpure-text"])]
-@@ -5217,9 +5417,9 @@
+@@ -5242,9 +5442,9 @@ fi
  # checks for library functions
  AC_CHECK_FUNCS([ \
    accept4 alarm bind_textdomain_codeset chmod chown clock closefrom close_range confstr \
--  copy_file_range ctermid dup dup3 execv explicit_bzero explicit_memset \
-+  copy_file_range ctermid dup dup3 explicit_bzero explicit_memset \
+-  copy_file_range ctermid dup execv explicit_bzero explicit_memset \
++  copy_file_range ctermid dup explicit_bzero explicit_memset \
    faccessat fchmod fchmodat fchown fchownat fdopendir fdwalk fexecve \
 -  fork fork1 fpathconf fstatat ftime ftruncate futimens futimes futimesat \
 +  fpathconf fstatat ftime ftruncate futimens futimes futimesat \
    gai_strerror getegid geteuid getgid getgrent getgrgid getgrgid_r \
    getgrnam_r getgrouplist gethostname getitimer getloadavg getlogin getlogin_r \
    getpeername getpgid getpid getppid getpriority _getpty \
-@@ -5227,15 +5427,14 @@
+@@ -5252,15 +5452,14 @@ AC_CHECK_FUNCS([ \
    getspnam getuid getwd grantpt if_nameindex initgroups kill killpg lchown linkat \
    lockf lstat lutimes madvise mbrtowc memrchr mkdirat mkfifo mkfifoat \
    mknod mknodat mktime mmap mremap nice openat opendir pathconf pause pipe \
--  pipe2 plock poll posix_fadvise posix_fallocate posix_openpt posix_spawn posix_spawnp \
+-  plock poll posix_fadvise posix_fallocate posix_openpt posix_spawn posix_spawnp \
 -  posix_spawn_file_actions_addclosefrom_np \
-+  pipe2 plock poll posix_fadvise posix_fallocate posix_openpt \
++  plock poll posix_fadvise posix_fallocate posix_openpt \
    pread preadv preadv2 process_vm_readv pthread_cond_timedwait_relative_np pthread_condattr_setclock pthread_init \
    pthread_kill ptsname ptsname_r pwrite pwritev pwritev2 readlink readlinkat readv realpath renameat \
    rtpSpawn sched_get_priority_max sched_rr_get_interval sched_setaffinity \
@@ -7931,7 +7931,7 @@ index 597a44b331a..5109db2f48f 100644
    sigfillset siginterrupt sigpending sigrelse sigtimedwait sigwait \
    sigwaitinfo snprintf splice strftime strlcpy strsignal symlinkat sync \
    sysconf tcgetpgrp tcsetpgrp tempnam timegm times tmpfile \
-@@ -5250,12 +5449,20 @@
+@@ -5275,14 +5474,22 @@ if test "$MACHDEP" != linux; then
    AC_CHECK_FUNCS([lchmod])
  fi
  
@@ -7941,21 +7941,22 @@ index 597a44b331a..5109db2f48f 100644
  # header definition prevents usage - autoconf doesn't use the headers), or
  # raise an error if used at runtime. Force these symbols off.
 -if test "$ac_sys_system" != "iOS" ; then
--  AC_CHECK_FUNCS([getentropy getgroups system])
 +if test "$ac_sys_system" != "iOS" -a "$ac_sys_system" != "tvOS" -a "$ac_sys_system" != "visionOS" -a "$ac_sys_system" != "watchOS" ; then
-+  AC_CHECK_FUNCS([ getentropy getgroups system ])
-+fi
-+
+   AC_CHECK_FUNCS([dup3 getentropy getgroups pipe2 system])
+ fi
+ 
 +# tvOS/watchOS have some additional methods that can be found, but not used.
 +if test "$ac_sys_system" != "tvOS" -a "$ac_sys_system" != "watchOS" ; then
 +  AC_CHECK_FUNCS([ \
 +    execv fork fork1 posix_spawn posix_spawnp posix_spawn_file_actions_addclosefrom_np \
 +    sigaltstack \
 +  ])
- fi
- 
++fi
++
  AC_CHECK_DECL([dirfd],
-@@ -5518,20 +5725,22 @@
+               [AC_DEFINE([HAVE_DIRFD], [1],
+                          [Define if you have the 'dirfd' function or macro.])],
+@@ -5543,20 +5750,22 @@ AC_CHECK_DECLS([UT_NAMESIZE],
                [@%:@include <utmp.h>])
  
  # check for openpty, login_tty, and forkpty
@@ -7992,7 +7993,7 @@ index 597a44b331a..5109db2f48f 100644
  
  # check for long file support functions
  AC_CHECK_FUNCS([fseek64 fseeko fstatvfs ftell64 ftello statvfs])
-@@ -5570,10 +5779,10 @@
+@@ -5595,10 +5804,10 @@ AC_CHECK_FUNCS([clock_getres], [], [
      ])
  ])
  
@@ -8005,7 +8006,7 @@ index 597a44b331a..5109db2f48f 100644
  then
    AC_CHECK_FUNCS([clock_settime], [], [
        AC_CHECK_LIB([rt], [clock_settime], [
-@@ -5731,7 +5940,7 @@
+@@ -5756,7 +5965,7 @@ int main(void)
  [ac_cv_buggy_getaddrinfo=no],
  [ac_cv_buggy_getaddrinfo=yes],
  [
@@ -8014,7 +8015,7 @@ index 597a44b331a..5109db2f48f 100644
    ac_cv_buggy_getaddrinfo="no"
  elif test "${enable_ipv6+set}" = set; then
    ac_cv_buggy_getaddrinfo="no -- configured with --(en|dis)able-ipv6"
-@@ -6322,8 +6531,8 @@
+@@ -6347,8 +6556,8 @@ if test "$PY_ENABLE_SHARED" = "1" && ( test -n "$ANDROID_API_LEVEL" || test "$MA
    LIBPYTHON="\$(BLDLIBRARY)"
  fi
  
@@ -8025,7 +8026,7 @@ index 597a44b331a..5109db2f48f 100644
    MODULE_DEPS_SHARED="$MODULE_DEPS_SHARED \$(PYTHONFRAMEWORKDIR)/\$(PYTHONFRAMEWORK)"
  fi
  
-@@ -6931,7 +7140,7 @@
+@@ -6956,7 +7165,7 @@ AC_MSG_NOTICE([checking for device files])
  dnl NOTE: Inform user how to proceed with files when cross compiling.
  dnl Some cross-compile builds are predictable; they won't ever
  dnl have /dev/ptmx or /dev/ptc, so we can set them explicitly.
@@ -8034,7 +8035,7 @@ index 597a44b331a..5109db2f48f 100644
    ac_cv_file__dev_ptmx=no
    ac_cv_file__dev_ptc=no
  else
-@@ -7188,7 +7397,7 @@
+@@ -7213,7 +7422,7 @@ AC_ARG_WITH([ensurepip],
        AS_CASE([$ac_sys_system],
          [Emscripten], [with_ensurepip=no],
          [WASI], [with_ensurepip=no],
@@ -8043,7 +8044,7 @@ index 597a44b331a..5109db2f48f 100644
          [with_ensurepip=upgrade]
        )
      ])
-@@ -7596,7 +7805,7 @@
+@@ -7621,7 +7830,7 @@ AS_CASE([$ac_sys_system],
    [VxWorks*], [PY_STDLIB_MOD_SET_NA([_scproxy], [termios], [grp])],
    dnl The _scproxy module is available on macOS
    [Darwin], [],


### PR DESCRIPTION
Follow-up to the 3.13.13→3.13.14 / 3.14.5→3.14.6 bump (#11), which broke CI ([run](https://github.com/flet-dev/python-build/actions/runs/27355322963)). Two independent root causes:

## 1. iOS 3.13 build — patch no longer applied
`darwin/ios_patches/3.13/Python.patch` back-ports CPython's Apple build tooling and was generated against 3.13.13. CPython **3.13.14 reworked the `AC_CHECK_FUNCS` block** in `configure`/`configure.ac` (it moved `dup3`/`pipe2` into the non-iOS conditional), so the patch failed:

```
1 out of 43 hunks failed--saving rejects to configure.rej
3 out of 36 hunks failed--saving rejects to configure.ac.rej
```

Regenerated the `configure` + `configure.ac` sections of the patch against 3.13.14, **merging** the back-port's tvOS/visionOS/watchOS `AC_CHECK_FUNCS` handling with 3.13.14's `dup3`/`pipe2` move (both forced off across all four embedded Apple platforms). Everything else in the patch (the Apple/ tooling files) is byte-for-byte unchanged.

**Validation:** the regenerated patch applies with `patch -p1 --force` against a pristine 3.13.14 source tree with **0 rejects**, and produces a tree identical to the reference.

## 2. Linux + Android — `Setup Python` failed
```
The version '3.13.14' with architecture 'x64' was not found for Ubuntu 24.04.
```
GitHub's hosted-runner Python manifest doesn't carry freshly-released patch versions yet. These jobs installed the **full** version; the host interpreter is only a build driver (the target Python is built from source / fetched as python-build-standalone), so only the **minor** version matters. Switched them to `PYTHON_VERSION_SHORT` — matching what the **Darwin and Windows jobs already do**. Also future-proofs against the manifest lagging on later bumps.

## Not changed
- 3.14.x uses CPython's native in-tree Apple tooling (no patch), so only fix #2 applies to 3.14.6.
- The 3.12.13 / Windows job failures in the linked run were run cancellations, not real errors.