### PR TITLE
PBS-style date-keyed releases + Node 24 actions

### DIFF
--- a/.github/workflows/build-python-version.yml
+++ b/.github/workflows/build-python-version.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Derive short Python version
         shell: bash
@@ -72,7 +72,7 @@ jobs:
           bash ./package-macos-for-dart.sh . "$PYTHON_VERSION"
 
       - name: Upload Darwin build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: python-darwin-${{ env.PYTHON_VERSION }}
           path: darwin/dist/python-*.tar.gz
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Derive short Python version
         shell: bash
@@ -125,7 +125,7 @@ jobs:
         run: python3 -m unittest discover -s android/tests -t android/tests -v
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: python-android-${{ env.PYTHON_VERSION }}
           path: android/dist/python-android-*.tar.gz
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Derive short Python version
         shell: bash
@@ -158,7 +158,7 @@ jobs:
           bash ./package-for-linux.sh aarch64 ""
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: python-linux-${{ env.PYTHON_VERSION }}
           path: linux/python-linux-dart-*.tar.gz
@@ -168,7 +168,7 @@ jobs:
     name: Build Python for Windows
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Derive short Python version
         shell: pwsh
@@ -189,7 +189,7 @@ jobs:
             -PythonVersionShort "${{ env.PYTHON_VERSION_SHORT }}"
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: python-windows-${{ env.PYTHON_VERSION }}
           path: windows/python-windows-for-dart-*.zip

--- a/.github/workflows/build-python-version.yml
+++ b/.github/workflows/build-python-version.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Derive short Python version
         shell: bash
@@ -72,7 +72,7 @@ jobs:
           bash ./package-macos-for-dart.sh . "$PYTHON_VERSION"
 
       - name: Upload Darwin build artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: python-darwin-${{ env.PYTHON_VERSION }}
           path: darwin/dist/python-*.tar.gz
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Derive short Python version
         shell: bash
@@ -125,7 +125,7 @@ jobs:
         run: python3 -m unittest discover -s android/tests -t android/tests -v
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: python-android-${{ env.PYTHON_VERSION }}
           path: android/dist/python-android-*.tar.gz
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Derive short Python version
         shell: bash
@@ -158,7 +158,7 @@ jobs:
           bash ./package-for-linux.sh aarch64 ""
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: python-linux-${{ env.PYTHON_VERSION }}
           path: linux/python-linux-dart-*.tar.gz
@@ -168,7 +168,7 @@ jobs:
     name: Build Python for Windows
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Derive short Python version
         shell: pwsh
@@ -189,7 +189,7 @@ jobs:
             -PythonVersionShort "${{ env.PYTHON_VERSION_SHORT }}"
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: python-windows-${{ env.PYTHON_VERSION }}
           path: windows/python-windows-for-dart-*.zip

--- a/.github/workflows/build-python-version.yml
+++ b/.github/workflows/build-python-version.yml
@@ -58,18 +58,23 @@ jobs:
 
           # mobile-forge artifact: iOS-only install+support tree (same structure as before).
           # Captured before the macOS build also writes into ./support / ./install.
-          tar -czf dist/python-ios-mobile-forge-$PYTHON_VERSION_SHORT.tar.gz install support
+          tar -czf dist/python-ios-mobile-forge-$PYTHON_VERSION.tar.gz install support
 
           # macOS: universal2 framework built from source (all versions).
           python build_macos.py "$PYTHON_VERSION"
 
-          bash ./package-ios-for-dart.sh . "$PYTHON_VERSION_SHORT"
-          bash ./package-macos-for-dart.sh . "$PYTHON_VERSION_SHORT"
+          # Package scripts receive the FULL Python version: the tarball name
+          # carries it verbatim so a date-keyed release can host multiple
+          # patches of the same minor (e.g. 3.14.5 + 3.14.6) side by side.
+          # Internal lookups inside the scripts derive the short version
+          # themselves where they need it.
+          bash ./package-ios-for-dart.sh . "$PYTHON_VERSION"
+          bash ./package-macos-for-dart.sh . "$PYTHON_VERSION"
 
       - name: Upload Darwin build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: python-darwin-${{ env.PYTHON_VERSION_SHORT }}
+          name: python-darwin-${{ env.PYTHON_VERSION }}
           path: darwin/dist/python-*.tar.gz
           if-no-files-found: error
 
@@ -102,7 +107,7 @@ jobs:
         run: |
           bash ./build-all.sh "$PYTHON_VERSION"
           mkdir -p dist
-          tar -czf dist/python-android-mobile-forge-$PYTHON_VERSION_SHORT.tar.gz install support
+          tar -czf dist/python-android-mobile-forge-$PYTHON_VERSION.tar.gz install support
           bash ./package-for-dart.sh install "$PYTHON_VERSION" arm64-v8a
           bash ./package-for-dart.sh install "$PYTHON_VERSION" x86_64
           read version_major version_minor < <(echo "$PYTHON_VERSION" | sed -E 's/^([0-9]+)\.([0-9]+).*/\1 \2/')
@@ -122,7 +127,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: python-android-${{ env.PYTHON_VERSION_SHORT }}
+          name: python-android-${{ env.PYTHON_VERSION }}
           path: android/dist/python-android-*.tar.gz
           if-no-files-found: error
 
@@ -155,7 +160,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: python-linux-${{ env.PYTHON_VERSION_SHORT }}
+          name: python-linux-${{ env.PYTHON_VERSION }}
           path: linux/python-linux-dart-*.tar.gz
           if-no-files-found: error
 
@@ -186,42 +191,10 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: python-windows-${{ env.PYTHON_VERSION_SHORT }}
+          name: python-windows-${{ env.PYTHON_VERSION }}
           path: windows/python-windows-for-dart-*.zip
           if-no-files-found: error
 
-  publish-release:
-    name: Publish Release Assets
-    runs-on: ubuntu-latest
-    # Only publish GitHub release assets from the main branch; other branches still
-    # build (and upload per-job artifacts) but don't touch releases.
-    if: github.ref == 'refs/heads/main'
-    needs:
-      - build-darwin
-      - build-android
-      - build-linux
-      - build-windows
-    permissions:
-      contents: write
-    steps:
-      - name: Derive short Python version
-        shell: bash
-        run: |
-          echo "PYTHON_VERSION_SHORT=$(echo "$PYTHON_VERSION" | cut -d. -f1,2)" >> "$GITHUB_ENV"
-
-      - name: Download all build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: python-*-${{ env.PYTHON_VERSION_SHORT }}
-          path: release-artifacts
-          merge-multiple: true
-
-      - name: Publish all artifacts to release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ env.PYTHON_VERSION_SHORT }}
-          files: release-artifacts/*
-          fail_on_unmatched_files: true
-          generate_release_notes: false
-          draft: false
-          prerelease: false
+  # The publish-release job lives in the parent workflow (build-python.yml):
+  # date-keyed releases collect tarballs from every matrix entry into one
+  # release, so the publish step has to run after the full matrix completes.

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -4,6 +4,16 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+    inputs:
+      release_date:
+        description: >
+          Release tag (YYYYMMDD). When set, a single GitHub release with that
+          tag is created and all per-platform tarballs from every matrix entry
+          are published as assets. Leave empty for a build-only run that uploads
+          per-job artifacts but does not publish a release.
+        required: false
+        type: string
+        default: ""
 
 # Cancel in-flight runs when a newer event arrives for the same logical branch.
 concurrency:
@@ -24,3 +34,34 @@ jobs:
     with:
       python_version: ${{ matrix.python_version }}
     secrets: inherit
+
+  publish-release:
+    name: Publish Release Assets
+    runs-on: ubuntu-latest
+    # Date-keyed releases (PBS-style): only publish when an operator explicitly
+    # triggers via workflow_dispatch with a `release_date` input. Pushes still
+    # exercise the matrix but leave per-job artifacts for inspection and do
+    # not touch GitHub releases.
+    if: github.event_name == 'workflow_dispatch' && inputs.release_date != ''
+    needs:
+      - build-matrix
+    permissions:
+      contents: write
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: python-*
+          path: release-artifacts
+          merge-multiple: true
+
+      - name: Publish all artifacts to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.release_date }}
+          name: ${{ inputs.release_date }}
+          files: release-artifacts/*
+          fail_on_unmatched_files: true
+          generate_release_notes: false
+          draft: false
+          prerelease: false

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -49,7 +49,7 @@ jobs:
       contents: write
     steps:
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: python-*
           path: release-artifacts

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -49,14 +49,14 @@ jobs:
       contents: write
     steps:
       - name: Download all build artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: python-*
           path: release-artifacts
           merge-multiple: true
 
       - name: Publish all artifacts to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.release_date }}
           name: ${{ inputs.release_date }}

--- a/android/package-for-dart.sh
+++ b/android/package-for-dart.sh
@@ -121,5 +121,7 @@ done
 
 rm -rf $build_dir/lib
 
-# final archive
-tar -czf dist/python-android-dart-$python_version_short-$abi.tar.gz -C $build_dir .
+# final archive — filename uses the FULL python version (e.g. 3.14.6, not
+# 3.14) so a single date-keyed release can host multiple patches of the
+# same minor side by side.
+tar -czf dist/python-android-dart-$python_version-$abi.tar.gz -C $build_dir .

--- a/darwin/package-ios-for-dart.sh
+++ b/darwin/package-ios-for-dart.sh
@@ -82,5 +82,7 @@ rm -rf __pycache__
 rm -rf **/__pycache__
 cd -
 
-# final archive
-tar -czf dist/python-ios-dart-$python_version_short.tar.gz -C $build_dir .
+# final archive — filename uses the FULL python version (e.g. 3.14.6, not
+# 3.14) so a single date-keyed release can host multiple patches of the
+# same minor side by side.
+tar -czf dist/python-ios-dart-$python_version.tar.gz -C $build_dir .

--- a/linux/package-for-linux.sh
+++ b/linux/package-for-linux.sh
@@ -47,5 +47,7 @@ fi
 mkdir -p $PYTHON_ARCH/dist
 rsync -av --exclude-from=python-linux-dart.exclude $PYTHON_ARCH/build/python/* $PYTHON_ARCH/dist
 
-# archive
-tar -czf "python-linux-dart-$PYTHON_VERSION_SHORT-$PYTHON_ARCH.tar.gz" -C "$PYTHON_ARCH/dist" .
+# archive — filename uses the FULL python version (e.g. 3.14.6, not 3.14)
+# so a single date-keyed release can host multiple patches of the same
+# minor side by side.
+tar -czf "python-linux-dart-$PYTHON_VERSION-$PYTHON_ARCH.tar.gz" -C "$PYTHON_ARCH/dist" .

--- a/windows/package-for-dart.ps1
+++ b/windows/package-for-dart.ps1
@@ -20,8 +20,10 @@ $srcDir = Join-Path $srcRoot "Python-$PythonVersion"
 $pcbuildDir = Join-Path $srcDir "PCbuild\amd64"
 $pythonTag = $PythonVersionShort -replace '\.', ''
 
-$packageRoot = Join-Path $workspace "windows\python-windows-for-dart-$PythonVersionShort"
-$zipPath = Join-Path $workspace "windows\python-windows-for-dart-$PythonVersionShort.zip"
+# Filename uses the FULL python version (e.g. 3.14.6, not 3.14) so a single
+# date-keyed release can host multiple patches of the same minor side by side.
+$packageRoot = Join-Path $workspace "windows\python-windows-for-dart-$PythonVersion"
+$zipPath = Join-Path $workspace "windows\python-windows-for-dart-$PythonVersion.zip"
 $excludeListPath = Join-Path $workspace "windows\python-windows-dart.exclude"
 $keepImportLibs = @("python3.lib", "python3_d.lib", "python$pythonTag.lib", "python${pythonTag}_d.lib")
 


### PR DESCRIPTION
## Summary

Restructure `python-build`'s release workflow to mirror what
[`astral-sh/python-build-standalone`](https://github.com/astral-sh/python-build-standalone/releases)
does: a single GitHub release per **date**, containing every per-platform
tarball from every Python version in one place. Tarball filenames carry
the **full** Python version (`3.14.6`) so multiple patches of the same
minor can coexist in one release.

### Why move off one-release-per-minor

- Re-cutting a release for a build fix (the `Python.app` strip in #N is
  the immediate example) had to clobber an existing `v3.14` tag, which
  breaks reproducibility for any downstream that pinned to it.
- Several platform fixes recently had to wait for a coordinated "all
  minors get a fresh tarball" moment. Date tags decouple that — cut a
  new date once everything we care about builds, downstreams pick it up
  when they bump their `PYTHON_BUILD_RELEASE` pin.
- Symmetric with how `flet-dev/serious-python`'s `package_command`
  already pins its `astral-sh/python-build-standalone` tarball by date.

## Changes

### `build-python.yml`
- `workflow_dispatch` gains a `release_date` input (`YYYYMMDD`).
- New `publish-release` job runs after the matrix, downloads every
  per-platform artifact, and publishes a single GitHub release tagged
  by that date.
- Publish only fires on `workflow_dispatch` with a non-empty
  `release_date`. Pushes still exercise the matrix (artifacts available
  for inspection) but never touch releases.

### `build-python-version.yml`
- Per-version `publish-release` job removed (moved to parent).
- Artifact upload names now include the **full** Python version
  (`python-darwin-3.14.6` instead of `python-darwin-3.14`) so the
  parent workflow can ingest multiple patches of the same minor
  without artifact-name collisions.
- Darwin packagers receive the full version directly.

### Per-platform packagers (darwin/ios, android, linux, windows)
- Tarball / zip filenames switch from `$PYTHON_VERSION_SHORT` to the
  full `$PYTHON_VERSION` (e.g. `python-macos-dart-3.14.6.tar.gz`).
  Internal lookups that need the short version derive it inline.
- `mobile-forge` artifacts follow the same naming convention.

### CI hygiene
- Bumped `actions/checkout`, `actions/upload-artifact`,
  `actions/download-artifact`, and `softprops/action-gh-release` to
  their latest majors (Node 24). Clears the 12 Node-20 deprecation
  warnings emitted by every matrix entry on the previous run.

## Downstream impact (separate PR in `flet-dev/serious-python`)

After this merges and the first date-keyed release is cut, the five
plugins in `serious-python` need a follow-up to:

1. Read a new `PYTHON_BUILD_RELEASE` (`YYYYMMDD`) env var instead of
   composing URLs with `v$PYTHON_VERSION`.
2. Reference tarballs by full Python version in the URL.
3. Cache layout: `$FLET_CACHE_DIR/python-build/<release>/<file>`.

That migration is independent of this PR.

## Test plan

- [ ] CI matrix on this branch builds green (every platform × version).
- [ ] On merge: trigger `workflow_dispatch` with `release_date: <today>`,
      confirm a single release is published with all 4 platforms × 3
      Python versions worth of tarballs.
- [ ] Confirm tarballs name themselves with the full version
      (`python-macos-dart-3.14.6.tar.gz`, not `…-3.14.tar.gz`).
- [ ] Confirm the `softprops/action-gh-release@v3` publish step
      succeeds end-to-end.