### PR TITLE
Bump dart_bridge_version to 1.3.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "default_python_version": "3.14",
-  "dart_bridge_version": "1.2.3",
+  "dart_bridge_version": "1.3.0",
   "pythons": {
     "3.12": {
       "full_version": "3.12.13",


### PR DESCRIPTION
libdart_bridge 1.3.0 adds:
* dart_bridge_is_python_initialized / dart_bridge_signal_dart_session C exports for Android process-reuse (Dart VM restart while the OS keeps the process + Python alive).
* Native sys.stdout / sys.stderr redirection to logcat (Android), os_log (iOS/macOS), stderr (desktop) installed right after Py_Initialize.
* dart_bridge.add_session_restart_handler Python API for the running program to subscribe to new-VM signals.

Release notes: https://github.com/flet-dev/dart-bridge/releases/tag/v1.3.0

Consumer-side changes (serious-python FFI bindings + flet build template + flet.app runtime) are wired with soft symbol lookups so pre-1.3.0 binaries still load — but with this bump, real process-reuse behaviour activates end-to-end.