### PR TITLE
Bump dart_bridge_version to 1.3.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "default_python_version": "3.14",
-  "dart_bridge_version": "1.3.0",
+  "dart_bridge_version": "1.3.1",
   "pythons": {
     "3.12": {
       "full_version": "3.12.13",


### PR DESCRIPTION
Update manifest.json to use dart_bridge_version 1.3.1 (previously 1.3.0). This patches the Dart bridge dependency; no other manifest fields were modified.