### PR TITLE
Bump dart_bridge_version to 1.3.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "default_python_version": "3.14",
-  "dart_bridge_version": "1.3.1",
+  "dart_bridge_version": "1.3.2",
   "pythons": {
     "3.12": {
       "full_version": "3.12.13",


### PR DESCRIPTION
Update manifest.json to upgrade dart_bridge_version from 1.3.1 to 1.3.2. This applies a patch version bump for the Dart bridge; no other manifest fields were changed.