### PR TITLE
Bump dart_bridge_version to 1.4.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "default_python_version": "3.14",
-  "dart_bridge_version": "1.3.2",
+  "dart_bridge_version": "1.4.0",
   "pythons": {
     "3.12": {
       "full_version": "3.12.13",


### PR DESCRIPTION
Update manifest.json to use dart_bridge_version 1.4.0 (was 1.3.2). Aligns the project with the newer Dart bridge release.