### PR TITLE
Remove 32-bit x86 Android ABI references

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -22,7 +22,7 @@ To build all ABIs:
 ```
 
 ABI support:
-* Python 3.12: `arm64-v8a`, `armeabi-v7a`, `x86_64`, `x86`
+* Python 3.12: `arm64-v8a`, `armeabi-v7a`, `x86_64`
 * Python 3.13+: `arm64-v8a`, `x86_64`
 
 ## Credits

--- a/android/abi-to-host.sh
+++ b/android/abi-to-host.sh
@@ -5,9 +5,6 @@ case ${abi:?} in
     arm64-v8a)
         HOST=aarch64-linux-android
         ;;
-    x86)
-        HOST=i686-linux-android
-        ;;
     x86_64)
         HOST=x86_64-linux-android
         ;;

--- a/android/build-all.sh
+++ b/android/build-all.sh
@@ -10,7 +10,7 @@ version_int=$((version_major * 100 + version_minor))
 if [ $version_int -ge 313 ]; then
     abis="arm64-v8a x86_64"
 else
-    abis="arm64-v8a armeabi-v7a x86_64 x86"
+    abis="arm64-v8a armeabi-v7a x86_64"
 fi
 
 for abi in $abis; do


### PR DESCRIPTION
## Summary

Flutter does not produce the 32-bit `x86` ABI for Android, so building and packaging Python for it is dead weight. This drops every reference to the bare `x86` ABI.

`x86_64` (64-bit) and `armeabi-v7a` are **retained** — both are still produced by Flutter.

## Changes

- `android/build-all.sh` — remove `x86` from the pre-3.13 ABI list
- `android/abi-to-host.sh` — remove the `x86) → i686-linux-android` case
- `android/README.md` — drop `x86` from the Python 3.12 ABI list

The CI workflow and `manifest.json` already did not reference `x86`.

## Verification

- `grep -rnE "x86([^_]|$)" android/` returns no bare `x86` matches (only `x86_64`)
- `abi-to-host.sh` still resolves `x86_64` → `x86_64-linux-android`; `x86` now hits the unknown-ABI fallback and exits non-zero