### PR TITLE
Manifest drives Android ABI list (per-minor android_abis)

### DIFF
--- a/.github/workflows/build-python-version.yml
+++ b/.github/workflows/build-python-version.yml
@@ -108,13 +108,18 @@ jobs:
           bash ./build-all.sh "$PYTHON_VERSION"
           mkdir -p dist
           tar -czf dist/python-android-mobile-forge-$PYTHON_VERSION.tar.gz install support
-          bash ./package-for-dart.sh install "$PYTHON_VERSION" arm64-v8a
-          bash ./package-for-dart.sh install "$PYTHON_VERSION" x86_64
-          read version_major version_minor < <(echo "$PYTHON_VERSION" | sed -E 's/^([0-9]+)\.([0-9]+).*/\1 \2/')
-          version_int=$((version_major * 100 + version_minor))
-          if [ $version_int -lt 313 ]; then
-            bash ./package-for-dart.sh install "$PYTHON_VERSION" armeabi-v7a
+          # ABIs come from the manifest (`pythons.<short>.android_abis`) so a
+          # future minor only needs a one-line edit there — not a workflow
+          # bump. 3.12 ships armeabi-v7a; 3.13+ are 64-bit only (PEP 738).
+          short="$PYTHON_VERSION_SHORT"
+          abis=$(jq -r --arg s "$short" '.pythons[$s].android_abis[]' "$GITHUB_WORKSPACE/manifest.json")
+          if [ -z "$abis" ]; then
+            echo "::error::manifest.json has no .pythons[\"$short\"].android_abis"
+            exit 1
           fi
+          while IFS= read -r abi; do
+            bash ./package-for-dart.sh install "$PYTHON_VERSION" "$abi"
+          done <<< "$abis"
 
       - name: Run post-build tests
         shell: bash

--- a/README.md
+++ b/README.md
@@ -28,19 +28,23 @@ Schema:
       "standalone_release_date": "20260610",
       "pyodide_version": "314.0.0",
       "pyodide_platform_tag": "pyemscripten-2026.0-wasm32",
+      "android_abis": ["arm64-v8a", "x86_64"],
       "prerelease": false
     }
   }
 }
 ```
 
+`android_abis` lists the ABIs `package-for-dart.sh` builds for this minor —
+64-bit first, then `armeabi-v7a` if the minor still supports 32-bit Android.
+3.12 carries all three; 3.13+ are 64-bit-only ([PEP 738](https://peps.python.org/pep-0738/)).
+
 The committed file omits `release`; the publish step injects it.
 
 ### Adding or bumping a Python / Pyodide / dart_bridge version
 
 Edit [`manifest.json`](manifest.json) and open a PR. The CI matrix updates
-automatically from it; per-version build specifics (ABIs, the 3.12 vs 3.13+ build
-method) live in the platform build scripts.
+automatically from it.
 
 ## Releases
 

--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,7 @@
       "standalone_release_date": "20260610",
       "pyodide_version": "0.27.7",
       "pyodide_platform_tag": "pyodide-2024.0-wasm32",
+      "android_abis": ["arm64-v8a", "x86_64", "armeabi-v7a"],
       "prerelease": false
     },
     "3.13": {
@@ -14,6 +15,7 @@
       "standalone_release_date": "20260610",
       "pyodide_version": "0.29.4",
       "pyodide_platform_tag": "pyemscripten-2025.0-wasm32",
+      "android_abis": ["arm64-v8a", "x86_64"],
       "prerelease": false
     },
     "3.14": {
@@ -21,6 +23,7 @@
       "standalone_release_date": "20260610",
       "pyodide_version": "314.0.0",
       "pyodide_platform_tag": "pyemscripten-2026.0-wasm32",
+      "android_abis": ["arm64-v8a", "x86_64"],
       "prerelease": false
     }
   }


### PR DESCRIPTION
## Summary
- Add an `android_abis` array per Python minor in `manifest.json` — 3.12 ships `["arm64-v8a", "x86_64", "armeabi-v7a"]`, 3.13/3.14 are 64-bit-only ([PEP 738](https://peps.python.org/pep-0738/)). Ordering keeps the 64-bit list as a prefix of the 32-bit one.
- Replace the hardcoded `version_int < 313 then armeabi-v7a` shell block in `.github/workflows/build-python-version.yml` with a `jq` read of `pythons.<short>.android_abis`, looped into `package-for-dart.sh`. Fails loudly if the manifest has no entry.
- README schema example + paragraph for the new field.

The intent is one-line-edit support for future minors: drop the `android_abis` line in the manifest and the build/publish/Gradle/CLI consumers (serious_python's `gen_version_tables`, flet's manifest-driven registry) flow it through automatically.

## Test plan
- [ ] CI matrix runs against the branch; the Android job log shows `package-for-dart.sh install <full_version> <abi>` invoked once per ABI listed in the manifest for each minor (3 for 3.12, 2 for 3.13/3.14).
- [ ] `jq '.pythons."3.12".android_abis' manifest.json` returns `["arm64-v8a", "x86_64", "armeabi-v7a"]`.
- [ ] After merge: cut a date-keyed release via `workflow_dispatch` and verify the published `manifest.json` asset carries `android_abis` on every row.