### PR TITLE
darwin/macos: keep bundled C extensions linker-signed (no explicit codesign)

### DIFF
--- a/darwin/build_macos.py
+++ b/darwin/build_macos.py
@@ -483,10 +483,19 @@ def make_relocatable(framework: Path, short: str) -> None:
 def codesign_framework(framework: Path, short: str) -> None:
     args = ["codesign", "-s", "-", "--preserve-metadata=identifier,entitlements,flags,runtime", "-f"]
     run(args + [framework / "Versions" / short / "Python"])
-    for pattern in ("*.dylib", "*.so"):
-        for binary in framework.rglob(pattern):
-            if binary.is_file():
-                run(args + [binary])
+    # Sign the framework binary and the bundled OpenSSL dylibs, but NOT the
+    # C-extension .so. strip_framework() already left them stripped and
+    # *linker-signed* (the replaceable adhoc signature install_name_tool/strip
+    # apply on arm64). Re-signing with `codesign -s -` would replace that with an
+    # *explicit* adhoc signature (CodeDirectory flags 0x2 instead of 0x20002),
+    # which a downstream Xcode app build refuses to strip ("not stripping binary
+    # because it is signed", once per extension) and won't re-sign. A
+    # linker-signed extension is instead re-signed into the consuming app
+    # cleanly, exactly like a pip wheel's .so. The .so are extracted to the
+    # stdlib resource tree, so they aren't covered by the framework's own seal.
+    for binary in framework.rglob("*.dylib"):
+        if binary.is_file():
+            run(args + [binary])
     run(args + [framework])
 
 


### PR DESCRIPTION
## Problem

macOS `lib-dynload/*.so` (and the bundled extensions generally) ship with an
**explicit** adhoc signature (CodeDirectory `flags=0x2`). When a downstream app
(Flutter/Xcode, via serious_python — SPM **or** CocoaPods) bundles them as
resources, Xcode's Release "strip" phase refuses to strip a code-signed Mach-O
(stripping invalidates the signature) and emits one warning **per extension**:

```
warning: not stripping binary because it is signed: .../lib-dynload/_ssl.cpython-3xx-darwin.so
```

…and the extensions stay unstripped, bloating the app.

## Root cause

`strip_framework()` already strips every `.so`/`.dylib`, and on arm64 they keep
the **linker-signed** adhoc signature (`flags=0x20002`) that `install_name_tool`
/ `strip` re-apply — a *replaceable* signature. `codesign_framework()` then
re-signs each `.so` with `codesign -s -`, **replacing** that with an *explicit*
adhoc signature (`0x2`), which the toolchain treats as final and won't strip or
re-sign.

A pip wheel's `.so` (e.g. numpy) keeps its linker-signed signature and sails
through Xcode's strip + re-sign with no warnings — the only difference was this
explicit re-sign.

## Fix

`codesign_framework()` now signs the framework binary and the bundled OpenSSL
`.dylib`, but **not** the C-extension `.so` — leaving them stripped +
linker-signed (replaceable), exactly like a wheel. They're extracted into the
stdlib resource tree, so they aren't covered by the framework's own seal.

## Verification (this branch's CI artifacts, run 27911450856)

- `lib-dynload/*.so`: **60/60 now `flags=0x20002 (adhoc, linker-signed)`** (was `0x2`), and smaller (`_ssl` 420000 → 387080).
- dyld loads them — a standalone `dlopen` fails only on undefined Python symbols, not on the signature.
- `codesign --verify` reports "not signed at all" — identical to a numpy wheel `.so` (the normal linker-signed quirk; the consuming app re-signs them).
- Framework `Python` binary + OpenSSL `libssl.dylib` unchanged (still explicit `0x2`).

Net for any consuming app (SPM or CocoaPods): the macOS extensions strip + re-sign cleanly — **no more per-extension "not stripping" warnings, smaller bundles.**