### PR TITLE
Build armeabi-v7a (32-bit ARM) for Python 3.13/3.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,11 @@ Schema:
 ```
 
 `android_abis` lists the ABIs `package-for-dart.sh` builds for this minor —
-64-bit first, then `armeabi-v7a` if the minor still supports 32-bit Android.
-3.12 carries all three; 3.13+ are 64-bit-only ([PEP 738](https://peps.python.org/pep-0738/)).
+64-bit (`arm64-v8a`, `x86_64`) plus 32-bit `armeabi-v7a`. [PEP 738](https://peps.python.org/pep-0738/)
+makes 64-bit Android the *tested* Tier-3 configuration, but CPython's official
+`Android/android.py` still builds 32-bit ARM (it's in its supported `HOSTS`), so
+all three minors carry `armeabi-v7a`. Drop an ABI from a minor's list to stop
+building it.
 
 The committed file omits `release`; the publish step injects it.
 

--- a/android/README.md
+++ b/android/README.md
@@ -21,9 +21,8 @@ To build all ABIs:
 ./build-all.sh 3.13.12
 ```
 
-ABI support:
-* Python 3.12: `arm64-v8a`, `armeabi-v7a`, `x86_64`
-* Python 3.13+: `arm64-v8a`, `x86_64`
+ABI support (all minors): `arm64-v8a`, `x86_64`, `armeabi-v7a`. The exact set
+built per minor is driven by `android_abis` in the top-level `manifest.json`.
 
 ## Credits
 

--- a/android/build-all.sh
+++ b/android/build-all.sh
@@ -5,14 +5,18 @@ python_version=${1:?}
 read version_major version_minor < <(
     echo "$python_version" | sed -E 's/^([0-9]+)\.([0-9]+).*/\1 \2/'
 )
-version_int=$((version_major * 100 + version_minor))
+short="$version_major.$version_minor"
 
-if [ $version_int -ge 313 ]; then
-    abis="arm64-v8a x86_64"
-else
-    abis="arm64-v8a armeabi-v7a x86_64"
+# ABIs come from the manifest (`pythons.<short>.android_abis`), the same source
+# the CI packaging step reads — keep them in lockstep so a minor's ABI set is
+# edited in exactly one place.
+manifest="$(dirname "$(realpath "$0")")/../manifest.json"
+abis=$(jq -r --arg s "$short" '.pythons[$s].android_abis[]' "$manifest")
+if [ -z "$abis" ]; then
+    echo "manifest.json has no .pythons[\"$short\"].android_abis" >&2
+    exit 1
 fi
 
 for abi in $abis; do
-    bash ./build.sh $python_version $abi
+    bash ./build.sh "$python_version" "$abi"
 done

--- a/android/build.sh
+++ b/android/build.sh
@@ -148,10 +148,10 @@ if [ $version_int -le 312 ]; then
     sed -i -e "s/_PYTHON_HOST_PLATFORM=.*/_PYTHON_HOST_PLATFORM=android-$api_level-$abi/" $PREFIX/lib/python$version_short/config-$version_short/Makefile
 else
     case "$abi" in
-        arm64-v8a|x86_64)
+        arm64-v8a|x86_64|armeabi-v7a)
             ;;
         *)
-            echo "Python $version_short official Android build supports only: arm64-v8a, x86_64"
+            echo "Python $version_short official Android build supports only: arm64-v8a, x86_64, armeabi-v7a"
             exit 1
             ;;
     esac

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
       "standalone_release_date": "20260623",
       "pyodide_version": "0.29.4",
       "pyodide_platform_tag": "pyemscripten-2025.0-wasm32",
-      "android_abis": ["arm64-v8a", "x86_64"],
+      "android_abis": ["arm64-v8a", "x86_64", "armeabi-v7a"],
       "prerelease": false
     },
     "3.14": {
@@ -23,7 +23,7 @@
       "standalone_release_date": "20260623",
       "pyodide_version": "314.0.1",
       "pyodide_platform_tag": "pyemscripten-2026.0-wasm32",
-      "android_abis": ["arm64-v8a", "x86_64"],
+      "android_abis": ["arm64-v8a", "x86_64", "armeabi-v7a"],
       "prerelease": false
     }
   }


### PR DESCRIPTION
## What & why

Adds `armeabi-v7a` (32-bit ARM) Android builds for Python 3.13 and 3.14, so all three minors now carry the same ABI set.

The repo previously treated 3.13+ as 64-bit-only, citing [PEP 738](https://peps.python.org/pep-0738/). That's inaccurate: PEP 738 makes 64-bit Android the *tested* Tier-3 configuration, but CPython's official `Android/android.py` still lists `arm-linux-androideabi` in its supported `HOSTS` (verified on both `v3.13.14` and `v3.14.6`), and beeware's `cpython-android-source-deps` publishes the matching `*-arm-linux-androideabi.tar.gz` dependency assets for every version 3.13/3.14 pin. The only real blocker was a self-imposed ABI gate in `build.sh`.

## Changes

- **`android/build.sh`** — allow `armeabi-v7a` through the 3.13+ official-build ABI case (the one blocker). Everything downstream (`abi-to-host.sh` → `arm-linux-androideabi`, `extract_mobile_forge_deps.py`, `normalize_mobile_forge_install.py`, `package-for-dart.sh`) was already ABI-agnostic and handled `armeabi-v7a` for 3.12.
- **`android/build-all.sh`** — read `android_abis` from `manifest.json` (the same source the CI packaging loop uses) instead of a separate hardcoded `3.13+ → 64-bit` gate. **Required for correctness**: CI builds via `build-all.sh` but packages from the manifest, so the two must agree or CI would try to package an ABI it never built. Now the ABI set lives in exactly one place.
- **`manifest.json`** — add `armeabi-v7a` to 3.13 and 3.14.
- **`README.md` / `android/README.md`** — correct the "3.13+ are 64-bit-only" note.

## Validation

Built and packaged locally via the official tooling — both green:

| Version | Build | Binaries | Dart tarball |
|---------|-------|----------|--------------|
| 3.14.6  | `android-arm`, 0 import failures | ELF32 / ARM | 11.5 MB |
| 3.13.14 | `android-arm`, 0 import failures | ELF32 / ARM | 10.3 MB |

Modules compiled with `armv7a-linux-androideabi24-clang -march=armv7-a`; deps (openssl/libffi/sqlite/xz/bzip2) downloaded as `*-arm-linux-androideabi.tar.gz`; `normalize` + packaging clean. `libpython3.{13,14}.so` and extension modules confirmed `ELF32 / Machine: ARM`.

## Note for reviewers

This repo only produces the runtime tarball. Shipping 32-bit apps also requires the downstream consumers (**serious_python**, **flet**, the **Dart bridge**) to accept and bundle the `armeabi-v7a` artifact — separate repos, out of scope here.