### PR TITLE
Bump dart_bridge_version to 1.4.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "default_python_version": "3.14",
-  "dart_bridge_version": "1.4.0",
+  "dart_bridge_version": "1.4.1",
   "pythons": {
     "3.12": {
       "full_version": "3.12.13",


### PR DESCRIPTION
## What

Bump `manifest.json` `dart_bridge_version` 1.4.0 → 1.4.1.

dart-bridge 1.4.1 adds `armeabi-v7a` (32-bit ARM) binaries for Python 3.13/3.14 (flet-dev/dart-bridge companion PR). This advertises that version to `serious_python` / flet, which read `dart_bridge_version` from this manifest.

`android_abis` already list `armeabi-v7a` for all minors, so no other manifest change is needed.

## Release

After merge, re-publish the **`20260629`** date-keyed release (dispatch `build-python.yml` with `release_date=20260629`) so the published `manifest.json` asset carries `dart_bridge_version: 1.4.1`. Keeping the same date avoids moving the pin in dart-bridge / serious_python / flet. serious_python then regenerates its snapshot to pick up 1.4.1.