### PR TITLE
Fix Python 3.13/3.14 on-device crashes: mimalloc seccomp open() + pruned _pyrepl

### DIFF
--- a/android/build.sh
+++ b/android/build.sh
@@ -57,6 +57,12 @@ if [ $version_int -eq 312 ]; then
     # Android tooling; this 3.12-only patch matches that behavior at link time.
     patches+=" soname_linktime bldlibrary grp"
 fi
+if [ $version_int -ge 313 ]; then
+    # mimalloc (bundled since 3.13) issues a bare SYS_open at load on x86_64,
+    # which Android seccomp kills (SIGSYS) at dlopen of libpython. Switch it to
+    # SYS_openat. See patches/mimalloc_seccomp_openat.patch.
+    patches+=" mimalloc_seccomp_openat"
+fi
 for name in $patches; do
     patch_file="$script_dir/patches/$name.patch"
     echo "$patch_file"

--- a/android/patches/mimalloc_seccomp_openat.patch
+++ b/android/patches/mimalloc_seccomp_openat.patch
@@ -1,0 +1,22 @@
+mimalloc: use SYS_openat instead of SYS_open (Android seccomp).
+
+CPython bundles mimalloc since 3.13. On Android, mimalloc's load-time constructor
+(mi_process_load -> unix_detect_overcommit, Objects/mimalloc/init.c) reads
+/proc/sys/vm/overcommit_memory through mi_prim_open. On platforms where SYS_open
+is defined (x86_64) mi_prim_open issues the bare open(2) syscall directly (to
+avoid recursion while mimalloc is still initializing). Android's bionic seccomp
+policy forbids open(2) -- only openat(2) is permitted -- so the kernel raises
+SIGSYS (SYS_SECCOMP) and the process is killed at dlopen() of libpython, before
+the interpreter starts. 3.12 has no mimalloc; arm64 is unaffected (it has no
+SYS_open, so mimalloc falls back to libc open(), which bionic routes through
+openat). SYS_openat(AT_FDCWD, ...) is semantically identical and allowed.
+
+--- a/Objects/mimalloc/prim/unix/prim.c
++++ b/Objects/mimalloc/prim/unix/prim.c
+@@ -67,5 +67,5 @@
+ static int mi_prim_open(const char* fpath, int open_flags) {
+-  return syscall(SYS_open,fpath,open_flags,0);
++  return syscall(SYS_openat,AT_FDCWD,fpath,open_flags,0);
+ }
+ static ssize_t mi_prim_read(int fd, void* buf, size_t bufsize) {
+   return syscall(SYS_read,fd,buf,bufsize);

--- a/android/python-android-dart.exclude
+++ b/android/python-android-dart.exclude
@@ -20,8 +20,8 @@ lib/python*/tkinter
 lib/python*/turtle*
 lib/python*/wsgiref
 # Interactive-REPL / dev-only modules + easter eggs / frozen demos (never imported when
-# running a script in embedded mode).
-lib/python*/_pyrepl
+# running a script in embedded mode). _pyrepl is intentionally NOT pruned: CPython 3.14's
+# pdb imports it at module load, so dropping it breaks pdb / pytest / anything that imports it.
 lib/python*/rlcompleter*
 lib/python*/tabnanny*
 lib/python*/antigravity*

--- a/darwin/python-darwin-stdlib.exclude
+++ b/darwin/python-darwin-stdlib.exclude
@@ -19,8 +19,9 @@ tkinter
 turtle*
 wsgiref
 # Interactive-REPL / dev-only modules — never imported when running a script (embedded
-# mode); plus easter eggs and frozen demo modules.
-_pyrepl
+# mode); plus easter eggs and frozen demo modules. _pyrepl is intentionally NOT pruned:
+# CPython 3.14's pdb imports it at module load, so dropping it breaks pdb / pytest /
+# anything that imports it on-device.
 rlcompleter*
 tabnanny*
 antigravity*


### PR DESCRIPTION
Two runtime bugs make Python 3.13/3.14 apps crash on mobile — before any app code runs. Both are `flet build` mobile-test blockers on 3.13/3.14 (3.12 is unaffected).

## Bug 1 — Android: mimalloc's raw `open(2)` is seccomp-killed (x86_64)

CPython bundles **mimalloc** starting in 3.13. Its load-time constructor (`_mi_process_init` → `mi_process_init`, an `.init_array` entry) reads `/proc/sys/vm/overcommit_memory` via `mi_prim_open`, which on platforms where `SYS_open` is defined (x86_64/x86/arm32) issues the **bare `open(2)` syscall directly** (to avoid recursion while the allocator is initializing). Android's bionic seccomp policy forbids `open(2)` — only `openat(2)` is allowed — so the kernel raises `SIGSYS` (`SYS_SECCOMP`) at `dlopen()` of `libpython`, before the interpreter starts. Every native import (indeed the whole app) dies.

- **arm64 is latent** (no `SYS_open`; mimalloc's `#else` path uses libc `open()`, which bionic routes through `openat`), so real arm64 devices are unaffected — but the CI/emulator target is x86_64, where it always crashes.
- **3.12 has no mimalloc**, so it never hit this.

**Fix:** `android/patches/mimalloc_seccomp_openat.patch` rewrites the one `mi_prim_open` call:
```diff
-  return syscall(SYS_open,fpath,open_flags,0);
+  return syscall(SYS_openat,AT_FDCWD,fpath,open_flags,0);
```
`SYS_openat(AT_FDCWD, …)` is semantically identical and is the syscall Android permits. Applied gated `>= 3.13` in `android/build.sh` (validated to apply to 3.13.14 and 3.14.6 sources).

## Bug 2 — iOS: `_pyrepl` is pruned but 3.14 `pdb` imports it

`_pyrepl` was excluded from the mobile stdlib as "interactive-REPL / dev-only". But CPython **3.14's `pdb.py` imports `_pyrepl` at module load**, so anything importing `pdb` (e.g. pytest's debugging plugin) dies with `ModuleNotFoundError: No module named '_pyrepl'`. 3.13's `pdb` doesn't import it, which is why 3.13 iOS was unaffected.

**Fix:** un-prune `_pyrepl` in `android/python-android-dart.exclude` and `darwin/python-darwin-stdlib.exclude`.

## Validation

Built green here (run 29187831914, all versions × platforms). Verified the fixed binaries directly: the x86_64 `libpython3.14.so`'s `mi_prim_open` site now emits `syscall(257=openat, AT_FDCWD)` instead of `syscall(2=open)`, and the stdlib bundle restores `stdlib/_pyrepl/`. Then ran it **end-to-end on-device via mobile-forge** (bundling this run's runtime): all six legs green — android + iOS × 3.12/3.13/3.14 — where android 3.13/3.14 and iOS 3.14 previously crashed.
