### PR TITLE
fix(desktop): stop pruning _pyrepl from Windows/Linux stdlib

### DIFF
--- a/android/python-android-dart.exclude
+++ b/android/python-android-dart.exclude
@@ -21,7 +21,8 @@ lib/python*/turtle*
 lib/python*/wsgiref
 # Interactive-REPL / dev-only modules + easter eggs / frozen demos (never imported when
 # running a script in embedded mode). _pyrepl is intentionally NOT pruned: CPython 3.14's
-# pdb imports it at module load, so dropping it breaks pdb / pytest / anything that imports it.
+# pydoc and pdb import it at module load, so dropping it breaks pydoc / pdb / pytest /
+# anything that imports them.
 lib/python*/rlcompleter*
 lib/python*/tabnanny*
 lib/python*/antigravity*

--- a/darwin/python-darwin-stdlib.exclude
+++ b/darwin/python-darwin-stdlib.exclude
@@ -20,8 +20,8 @@ turtle*
 wsgiref
 # Interactive-REPL / dev-only modules — never imported when running a script (embedded
 # mode); plus easter eggs and frozen demo modules. _pyrepl is intentionally NOT pruned:
-# CPython 3.14's pdb imports it at module load, so dropping it breaks pdb / pytest /
-# anything that imports it on-device.
+# CPython 3.14's pydoc and pdb import it at module load, so dropping it breaks
+# pydoc / pdb / pytest / anything that imports them.
 rlcompleter*
 tabnanny*
 antigravity*

--- a/linux/python-linux-dart.exclude
+++ b/linux/python-linux-dart.exclude
@@ -20,7 +20,8 @@ lib/python*/turtle*
 lib/python*/wsgiref
 # Interactive-REPL / dev-only modules + easter eggs / frozen demos (never imported when
 # running a script in embedded mode). Globs catch the .pyc too (sources go via *.py above).
-lib/python*/_pyrepl
+# _pyrepl is intentionally NOT pruned: CPython 3.14's pydoc and pdb import it at module
+# load, so dropping it breaks pydoc / pdb / pytest / anything that imports them.
 lib/python*/rlcompleter*
 lib/python*/tabnanny*
 lib/python*/antigravity*

--- a/windows/python-windows-dart.exclude
+++ b/windows/python-windows-dart.exclude
@@ -13,7 +13,8 @@ Lib/site-packages/pip*
 Lib/site-packages/setuptools*
 Lib/site-packages/wheel*
 # Interactive-REPL / dev-only modules + easter eggs / frozen demos.
-Lib/_pyrepl
+# _pyrepl is intentionally NOT pruned: CPython 3.14's pydoc and pdb import it at
+# module load, so dropping it breaks pydoc / pdb / pytest / anything that imports them.
 Lib/rlcompleter.py
 Lib/tabnanny.py
 Lib/antigravity.py


### PR DESCRIPTION
## Problem

Windows/Linux desktop apps built with Python 3.14 crash on startup when the app (or a dependency) imports `pydoc`:

```
File ".../Lib/pydoc.py", line 81, in <module>
ModuleNotFoundError: No module named '_pyrepl'
```

CPython 3.14's `pydoc.py` — and `pdb.py` — import `_pyrepl` at module load. The Windows and Linux Dart stdlib excludes prune `Lib/_pyrepl` as a "dev-only / interactive-REPL" module, so any desktop app importing `pydoc`/`pdb`/`pytest` (or a lib that does, e.g. NLTK) dies with `ModuleNotFoundError: No module named '_pyrepl'`.

## Fix

Stop pruning `_pyrepl` in `windows/python-windows-dart.exclude` and `linux/python-linux-dart.exclude`.

macOS/iOS/Android already un-pruned it in the mobile fix (#29, which cited `pdb`); this extends the same treatment to desktop and updates all comments to also cite `pydoc`, the trigger reported here.

Fixes flet-dev/serious-python#236