### PR TITLE
Use OpenSSL's official privacy manifest for _ssl/_hashlib

### DIFF
--- a/darwin/PrivacyInfo.xcprivacy
+++ b/darwin/PrivacyInfo.xcprivacy
@@ -1,17 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>NSPrivacyTracking</key>
-    <false/>
-    <key>NSPrivacyCollectedDataTypes</key>
-    <array/>
-    <key>NSPrivacyAccessedAPITypes</key>
-    <array/>
-    <key>NSPrivacyTrackingDomains</key>
-    <array/>
-    <key>NSPrivacyUsesNonStandardAPIs</key>
-    <false/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
## What

`darwin/PrivacyInfo.xcprivacy` — the manifest [copied into](https://github.com/flet-dev/python-build/blob/main/darwin/package-ios-for-dart.sh#L53-L54) `_ssl.framework` and `_hashlib.framework` — was a stub:

- `NSPrivacyAccessedAPITypes` was an empty `<array/>`
- it carried `NSPrivacyUsesNonStandardAPIs`, which is not a key in Apple's schema
- no trailing newline

Both frameworks statically link OpenSSL (`strings` on the shipped `_ssl` binary reports `OpenSSL 3.5.7`), so the right manifest is the one OpenSSL publishes for its Apple builds. This file is now byte-identical to [`openssl/openssl:os-dep/Apple/PrivacyInfo.xcprivacy`](https://github.com/openssl/openssl/blob/master/os-dep/Apple/PrivacyInfo.xcprivacy), which declares the file-timestamp API access the library actually performs (`NSPrivacyAccessedAPICategoryFileTimestamp`, reason `C617.1`).

`plutil -lint` clean.

## Why now

flet-dev/flet#6724 — a first App Store submission rejected with **ITMS-91065: Missing signature** for both `Frameworks/_ssl.framework/_ssl` and `Frameworks/_hashlib.framework/_hashlib`, citing BoringSSL / openssl_grpc.

**This change is not expected to fix that**, and shouldn't be presented as the fix. Apple emitted no ITMS-91061 alongside it, so it did find the manifest. Inspecting a real Flet IPA ruled out every signature-side explanation:

| Hypothesis | Finding |
| --- | --- |
| Framework ships unsigned in the IPA | Signed — valid Apple Development authority, correct `TeamIdentifier` |
| A vendor signature from python-build would survive | No — Xcode `--force` re-signs on embed; Google's own signature on `Flutter.framework` is overwritten with the app team's in the same IPA |
| Privacy manifest absent | Present, `plutil` clean |
| Manifest not sealed by the signature | Sealed — listed in both `files` and `files2` of `_CodeSignature/CodeResources` |

So the framework reaches Apple signed, with a sealed privacy manifest, and is still reported as unsigned. Root cause is still open; a DTS incident is the next step if a first-party submission reproduces it.

What this PR does is remove the one concrete defect that was verifiable, so it isn't a confound in that test.

## Follow-up

Needs a python-build release, then a snapshot re-pin in `flet-dev/serious-python`, before it reaches an app build.