### PR TITLE
Stamp Xcode build-provenance keys into generated framework Info.plists

### DIFF
--- a/darwin/xcframework_utils.sh
+++ b/darwin/xcframework_utils.sh
@@ -2,16 +2,56 @@ archs=("iphoneos.arm64" "iphonesimulator.arm64" "iphonesimulator.x86_64")
 
 dylib_ext=so
 
+# Build-provenance values that Xcode stamps into every framework Info.plist it
+# produces (DT* / BuildMachineOSBuild). The frameworks here are assembled by hand
+# from lib-dynload .so's, so without this they carry none of them and the bundle
+# doesn't look like it was built by Xcode at all -- which is the most substantive
+# difference we could find between our _ssl/_hashlib frameworks and third-party
+# OpenSSL xcframeworks that Apple's App Store scan accepts. See flet-dev/flet#6724.
+#
+# Resolved once per run: identical for every framework built from the same SDK.
+sdk_metadata_init() {
+    [ -n "${sdk_metadata_ready:-}" ] && return
+
+    build_machine_os_build=$(sw_vers -buildVersion)
+    sdk_version=$(xcrun --sdk iphoneos --show-sdk-version)
+    sdk_build=$(xcrun --sdk iphoneos --show-sdk-build-version)
+    xcode_build=$(xcodebuild -version | sed -n 's/^Build version //p')
+
+    # DTXcode is the Xcode version with the separators dropped, as major(2) +
+    # minor(1) + patch(1): 26.5 -> "2650", 16.2 -> "1620", 9.4.1 -> "0941".
+    local xcode_version major minor patch
+    xcode_version=$(xcodebuild -version | sed -n '1s/^Xcode //p')
+    IFS=. read -r major minor patch <<< "$xcode_version"
+    dt_xcode=$(printf '%02d%d%d' "$major" "${minor:-0}" "${patch:-0}")
+
+    sdk_metadata_ready=1
+}
+
 create_plist() {
     name=$1
     identifier=$2
     plist_file=$3
+    # "iphoneos" (default) or "iphonesimulator". The previous version hardcoded
+    # iPhoneOS for both slices, which mislabelled the simulator framework.
+    platform=${4:-iphoneos}
+
+    sdk_metadata_init
+
+    local supported_platform
+    if [ "$platform" = "iphonesimulator" ]; then
+        supported_platform=iPhoneSimulator
+    else
+        supported_platform=iPhoneOS
+    fi
 
     cat > $plist_file << PLIST_TEMPLATE
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BuildMachineOSBuild</key>
+	<string>$build_machine_os_build</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleName</key>
@@ -28,15 +68,50 @@ create_plist() {
 	<string>1.0</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
-		<string>iPhoneOS</string>
+		<string>$supported_platform</string>
 	</array>
-	<key>MinimumOSVersion</key>
-	<string>13.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>DTCompiler</key>
+	<string>com.apple.compilers.llvm.clang.1_0</string>
+	<key>DTPlatformBuild</key>
+	<string>$sdk_build</string>
+	<key>DTPlatformName</key>
+	<string>$platform</string>
+	<key>DTPlatformVersion</key>
+	<string>$sdk_version</string>
+	<key>DTSDKBuild</key>
+	<string>$sdk_build</string>
+	<key>DTSDKName</key>
+	<string>$platform$sdk_version</string>
+	<key>DTXcode</key>
+	<string>$dt_xcode</string>
+	<key>DTXcodeBuild</key>
+	<string>$xcode_build</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+PLIST_TEMPLATE
+
+    # Device slice only: the simulator framework is a fat arm64/x86_64 binary, so
+    # it can't claim an arm64 device capability.
+    if [ "$platform" != "iphonesimulator" ]; then
+        cat >> $plist_file << PLIST_CAPABILITIES
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
+PLIST_CAPABILITIES
+    fi
+
+    cat >> $plist_file << PLIST_TAIL
 </dict>
 </plist>
-PLIST_TEMPLATE
+PLIST_TAIL
 }
 
 # convert lib-dynloads to xcframeworks
@@ -66,7 +141,7 @@ create_xcframework_from_dylibs() {
     mv "$iphone_dir/$dylib_relative_path" $fd/$framework
     echo "Frameworks/$framework.framework/$framework" > "$iphone_dir/$dylib_without_ext.fwork"
     install_name_tool -id @rpath/$framework.framework/$framework $fd/$framework
-    create_plist $framework "org.python.$framework_identifier" $fd/Info.plist
+    create_plist $framework "org.python.$framework_identifier" $fd/Info.plist iphoneos
     echo "$origin_prefix/$dylib_without_ext.fwork" > $fd/$framework.origin
 
     # copy privacy manifest if any
@@ -84,7 +159,7 @@ create_xcframework_from_dylibs() {
     rm "$simulator_arm64_dir/$dylib_without_ext".*.$dylib_ext
     rm "$simulator_x86_64_dir/$dylib_without_ext".*.$dylib_ext
     install_name_tool -id @rpath/$framework.framework/$framework $fd/$framework
-    create_plist $framework "org.python.$framework_identifier" $fd/Info.plist
+    create_plist $framework "org.python.$framework_identifier" $fd/Info.plist iphonesimulator
     echo "$origin_prefix/$dylib_without_ext.fwork" > $fd/$framework.origin
 
     # copy privacy manifest if any


### PR DESCRIPTION
## What

`create_plist()` in `darwin/xcframework_utils.sh` wrote ten hand-authored keys and **not a single `DT*` key**. To Apple's static analysis, the frameworks we build from `lib-dynload` `.so`s don't look like anything Xcode produced.

It now emits the same key set Xcode stamps into a real framework, resolved once per run from the SDK actually in use (`sw_vers -buildVersion`, `xcrun --sdk iphoneos --show-sdk-version` / `--show-sdk-build-version`, `xcodebuild -version`):

```
BuildMachineOSBuild   DTPlatformName      DTSDKName      UIDeviceFamily
DTCompiler            DTPlatformVersion   DTXcode        UIRequiredDeviceCapabilities (device only)
DTPlatformBuild       DTSDKBuild          DTXcodeBuild
```

The generated key set is now **identical** to [krzyzanowskim/OpenSSL](https://github.com/krzyzanowskim/OpenSSL)'s `OpenSSL.framework` — verified by diffing both plists.

Also fixes a latent bug: the simulator slice previously claimed `CFBundleSupportedPlatforms=iPhoneOS`. `create_plist()` takes the platform as a fourth argument (default `iphoneos`) and now labels each slice correctly — `iPhoneSimulator` / `DTPlatformName=iphonesimulator` / `DTSDKName=iphonesimulator26.5`, and no `arm64` device capability on a fat arm64+x86_64 binary.

## Why

flet-dev/flet#6724 — `ITMS-91065: Missing signature` on `_ssl.framework` and `_hashlib.framework` for a first App Store submission.

These missing keys are the most substantive difference we could find between our frameworks and third-party OpenSSL xcframeworks Apple accepts. The other candidates were ruled out by experiment:

- **Source signature** — cannot matter. Re-signing krzyzanowskim's framework the way `exportArchive` does (`codesign -f --preserve-metadata=identifier,flags,runtime,launch-constraints,library-constraints`) destroys the certificate chain, team identifier and secure timestamp; only the identifier string survives, and that's derived from `CFBundleIdentifier` for an unsigned framework anyway.
- **Privacy manifest content** — cannot be the differentiator. The accepted third-party package ships an empty stub with `NSPrivacyAccessedAPITypes` as `<array/>`, and our frameworks already carry a manifest (Apple emits no `ITMS-91061` alongside the rejection).

**Whether this is what Apple's scan reads is unverified.** It's the cheapest remaining hypothesis and needs one App Store submission of a *new* app to test — the check only fires for new apps or updates that newly add a listed SDK, which is why existing Flet apps are unaffected.

## Verification

```
$ bash -n darwin/xcframework_utils.sh                          # syntax OK
$ plutil -lint out-device.plist out-sim.plist                  # both OK
$ diff <(keys out-device.plist) <(keys OpenSSL.framework/Info.plist)
  IDENTICAL key set
```

Device slice output:

```
BuildMachineOSBuild => 25F71      DTPlatformBuild => 23F81a    DTXcode      => 2660
DTCompiler => …clang.1_0          DTSDKName => iphoneos26.5    DTXcodeBuild => 17F113
CFBundleSupportedPlatforms => [iPhoneOS]                       UIDeviceFamily => [1, 2]
```

Needs a python-build release and a snapshot re-pin in `flet-dev/serious-python` before it reaches an app build.