### PR TITLE
Sign inner .framework bundles too; dart_bridge 1.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,17 @@ release (per-job artifacts only).
 ### Apple XCFramework signing
 
 Every `.xcframework` in the Darwin tarballs is provider-signed with the Flet
-publishing team's Apple Distribution identity and a secure timestamp.
+publishing team's Apple Distribution identity and a secure timestamp — **both the
+inner `.framework` bundles in each slice and the outer xcframework**, in that
+order.
+
+Signing only the outer bundle is not enough: an IPA built against such an
+artifact reports `signed = true` but `isSecureTimestamp = false`. Every slice of
+an XCFramework Apple's App Store scan demonstrably accepts
+([krzyzanowskim/OpenSSL](https://github.com/krzyzanowskim/OpenSSL)) carries its
+own signature, with the outer bundle signed last. The order matters — the outer
+seal hashes the bundle contents, so signing an inner framework afterwards
+invalidates it.
 
 This matters because Xcode records the state of each `.xcframework` an app links
 against **as its publisher shipped it**, and writes the result into the IPA as

--- a/darwin/xcframework_signing.sh
+++ b/darwin/xcframework_signing.sh
@@ -146,7 +146,39 @@ xcf_signing_identifier() {
     return 1
 }
 
-# Sign one completed outer XCFramework.
+# Emit the per-slice <Name>.framework bundles inside an xcframework.
+xcf_slice_frameworks() {
+    local xcf=$1
+    local name
+    name=$(basename "$xcf" .xcframework)
+
+    local slice
+    for slice in "$xcf"/*/; do
+        [ -d "$slice$name.framework" ] && printf '%s\n' "$slice$name.framework"
+    done
+    return 0
+}
+
+# Sign one completed outer XCFramework — inner frameworks first, outer last.
+#
+# WHY BOTH LAYERS
+#   Signing only the outer bundle is not enough. Compare against a third-party
+#   XCFramework Apple's App Store scan demonstrably accepts
+#   (github.com/krzyzanowskim/OpenSSL): every one of its ten slices carries its
+#   own Apple Distribution signature with a secure timestamp, and the outer
+#   bundle is signed afterwards. Our artifacts previously had unsigned inner
+#   frameworks, and their IPA receipts came back `signed = true` but
+#   `isSecureTimestamp = false` — the one structural difference between the two.
+#
+#   Order matters and is not optional: the outer seal hashes the bundle contents,
+#   so the inner signatures have to exist before it is computed. Signing an inner
+#   framework afterwards would invalidate the outer seal, which is the same
+#   mistake this whole effort exists to stop making.
+#
+#   `xcodebuild -create-xcframework` preserves inner `_CodeSignature`
+#   directories, so a producer may equally sign the .framework bundles before
+#   assembling the xcframework; doing it here keeps one code path for both the
+#   build-time and the sign-the-finished-archive callers.
 xcf_sign_one() {
     local xcf=$1
     [ -d "$xcf" ] || { xcf_err "not a directory: $xcf"; return 1; }
@@ -158,44 +190,55 @@ xcf_sign_one() {
         return 1
     fi
 
-    local args=(--force --timestamp -i "$ident" --sign "$XCFRAMEWORK_CODESIGN_IDENTITY")
+    local args=(--force --timestamp --sign "$XCFRAMEWORK_CODESIGN_IDENTITY")
     [ -n "${XCFRAMEWORK_SIGNING_KEYCHAIN:-}" ] && args+=(--keychain "$XCFRAMEWORK_SIGNING_KEYCHAIN")
 
-    xcf_log "signing $xcf as $ident"
-    # Deliberately no --deep: it re-signs nested code with the outer options and
-    # is documented by Apple as inappropriate for producing a distributable
-    # signature. Deliberately no --timestamp=none: the receipt's
-    # isSecureTimestamp is exactly what we are here to make true.
-    codesign "${args[@]}" "$xcf" || { xcf_err "codesign failed for $xcf"; return 1; }
-}
+    # Deliberately no --deep anywhere below: it re-signs nested code with the
+    # outer bundle's options and is documented by Apple as inappropriate for
+    # producing a distributable signature. Signing each slice explicitly is the
+    # supported way to get the same coverage. Deliberately no --timestamp=none:
+    # the receipt's isSecureTimestamp is exactly what we are here to make true.
+    local fw count=0
+    while IFS= read -r fw; do
+        [ -n "$fw" ] || continue
+        # No -i for the inner bundles: a .framework has a real CFBundleIdentifier
+        # in its own Info.plist, which codesign picks up.
+        codesign "${args[@]}" "$fw" || { xcf_err "codesign failed for $fw"; return 1; }
+        count=$((count + 1))
+    done <<EOF
+$(xcf_slice_frameworks "$xcf")
+EOF
 
-# Verify one outer XCFramework carries a real provider signature.
-xcf_verify_one() {
-    local xcf=$1
-    local expect_team=${XCFRAMEWORK_EXPECTED_TEAM_ID:-}
-    local expect_authority=${XCFRAMEWORK_EXPECTED_AUTHORITY:-Apple Distribution}
-
-    if [ ! -f "$xcf/_CodeSignature/CodeResources" ]; then
-        xcf_err "$xcf: no outer _CodeSignature/CodeResources — the XCFramework is unsigned"
+    if [ "$count" -eq 0 ]; then
+        xcf_err "$xcf: no slice frameworks found to sign"
         return 1
     fi
 
-    if ! codesign --verify --strict --verbose=4 "$xcf" 2>&1; then
-        xcf_err "$xcf: codesign --verify --strict failed"
+    xcf_log "signing $xcf as $ident ($count slice framework(s) + outer)"
+    codesign "${args[@]}" -i "$ident" "$xcf" || { xcf_err "codesign failed for $xcf"; return 1; }
+}
+
+# Assert one signed bundle (inner framework or outer xcframework) carries a real
+# provider signature: verifiable, not ad-hoc, securely timestamped, right
+# authority, right team.
+xcf_assert_signature() {
+    local target=$1
+    local expect_team=${XCFRAMEWORK_EXPECTED_TEAM_ID:-}
+    local expect_authority=${XCFRAMEWORK_EXPECTED_AUTHORITY:-Apple Distribution}
+
+    if ! codesign --verify --strict --verbose=4 "$target" 2>&1; then
+        xcf_err "$target: codesign --verify --strict failed"
         return 1
     fi
 
     local info
-    if ! info=$(codesign -dvvv "$xcf" 2>&1); then
-        xcf_err "$xcf: codesign -dvvv failed: $info"
+    if ! info=$(codesign -dvvv "$target" 2>&1); then
+        xcf_err "$target: codesign -dvvv failed: $info"
         return 1
     fi
-    printf '%s\n' "$info"
 
-    # An ad-hoc signature satisfies --verify but carries no identity at all, so
-    # it would sail past the checks below if they were the only ones.
     if printf '%s\n' "$info" | grep -q '^Signature=adhoc'; then
-        xcf_err "$xcf: ad-hoc signature; a release artifact needs a real identity"
+        xcf_err "$target: ad-hoc signature; a release artifact needs a real identity"
         return 1
     fi
 
@@ -203,12 +246,12 @@ xcf_verify_one() {
     # --timestamp reports `Signed Time=` instead, which is self-asserted and is
     # what makes an IPA receipt report isSecureTimestamp = false.
     if ! printf '%s\n' "$info" | grep -q '^Timestamp='; then
-        xcf_err "$xcf: no secure timestamp (signed without --timestamp?)"
+        xcf_err "$target: no secure timestamp (signed without --timestamp?)"
         return 1
     fi
 
     if ! printf '%s\n' "$info" | grep '^Authority=' | grep -qF "$expect_authority"; then
-        xcf_err "$xcf: no '$expect_authority' authority in the signature chain"
+        xcf_err "$target: no '$expect_authority' authority in the signature chain"
         return 1
     fi
 
@@ -216,10 +259,47 @@ xcf_verify_one() {
         local actual_team
         actual_team=$(printf '%s\n' "$info" | sed -n 's/^TeamIdentifier=//p' | head -1)
         if [ "$actual_team" != "$expect_team" ]; then
-            xcf_err "$xcf: TeamIdentifier '$actual_team' != expected '$expect_team'"
+            xcf_err "$target: TeamIdentifier '$actual_team' != expected '$expect_team'"
             return 1
         fi
     fi
+}
+
+# Verify one XCFramework carries real provider signatures on BOTH layers.
+xcf_verify_one() {
+    local xcf=$1
+
+    if [ ! -f "$xcf/_CodeSignature/CodeResources" ]; then
+        xcf_err "$xcf: no outer _CodeSignature/CodeResources — the XCFramework is unsigned"
+        return 1
+    fi
+
+    # Every slice's framework must be signed in its own right. An unsigned inner
+    # bundle is what produced `isSecureTimestamp = false` receipts even though the
+    # outer seal was valid — see xcf_sign_one.
+    local fw count=0
+    while IFS= read -r fw; do
+        [ -n "$fw" ] || continue
+        if [ ! -d "$fw/_CodeSignature" ] && [ ! -d "$fw/Versions/A/_CodeSignature" ]; then
+            xcf_err "$fw: inner framework is unsigned"
+            return 1
+        fi
+        xcf_assert_signature "$fw" >/dev/null || return 1
+        count=$((count + 1))
+    done <<EOF
+$(xcf_slice_frameworks "$xcf")
+EOF
+
+    if [ "$count" -eq 0 ]; then
+        xcf_err "$xcf: no slice frameworks found to verify"
+        return 1
+    fi
+
+    xcf_assert_signature "$xcf" || return 1
+
+    local info
+    info=$(codesign -dvvv "$xcf" 2>&1) || info=""
+    printf '%s\n' "$info"
 
     # The outer seal must name the same provider-owned identifier as the inner
     # framework. A mismatch means the bundle was re-signed by something that did

--- a/darwin/xcframework_signing.sh
+++ b/darwin/xcframework_signing.sh
@@ -124,16 +124,13 @@ xcf_find() {
 # depends on the consuming application.
 xcf_signing_identifier() {
     local xcf=$1
-    local name plist ident
-    name=$(basename "$xcf" .xcframework)
+    local fw plist ident
 
-    local slice
-    for slice in "$xcf"/*/; do
-        [ -d "$slice$name.framework" ] || continue
+    while IFS= read -r fw; do
+        [ -n "$fw" ] || continue
         # Flat (iOS) layout, then versioned (macOS). Versions/Current is a
         # symlink to the real version directory, so skip it.
-        for plist in "$slice$name.framework/Info.plist" \
-                     "$slice$name.framework"/Versions/*/Resources/Info.plist; do
+        for plist in "$fw/Info.plist" "$fw"/Versions/*/Resources/Info.plist; do
             [ -f "$plist" ] || continue
             case "$plist" in */Versions/Current/*) continue ;; esac
             ident=$(plutil -extract CFBundleIdentifier raw -o - "$plist" 2>/dev/null) || continue
@@ -142,19 +139,27 @@ xcf_signing_identifier() {
                 return 0
             fi
         done
-    done
+    done <<EOF
+$(xcf_slice_frameworks "$xcf")
+EOF
     return 1
 }
 
-# Emit the per-slice <Name>.framework bundles inside an xcframework.
+# Emit the per-slice .framework bundles inside an xcframework.
+#
+# Found by globbing each slice directory rather than by assuming the framework is
+# named after the xcframework. The two normally match, but a consumer may stage a
+# copy under a different name -- serious_python renames Python.xcframework to
+# Python-<platform>.xcframework -- and a name-keyed lookup silently finds nothing
+# there, which would let an unsigned slice pass as "no slices to check".
 xcf_slice_frameworks() {
     local xcf=$1
-    local name
-    name=$(basename "$xcf" .xcframework)
-
-    local slice
+    local slice fw
     for slice in "$xcf"/*/; do
-        [ -d "$slice$name.framework" ] && printf '%s\n' "$slice$name.framework"
+        [ -d "$slice" ] || continue
+        for fw in "$slice"*.framework; do
+            [ -d "$fw" ] && printf '%s\n' "$fw"
+        done
     done
     return 0
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "default_python_version": "3.14",
-  "dart_bridge_version": "1.7.0",
+  "dart_bridge_version": "1.7.1",
   "pythons": {
     "3.12": {
       "full_version": "3.12.13",


### PR DESCRIPTION
Follow-up to #37. Pairs with [dart-bridge#14](https://github.com/flet-dev/dart-bridge/pull/14) — both need to land, then a new dart_bridge release and a new date-keyed release here, before `serious_python` re-pins.

## The finding

20260729 signed each outer `.xcframework` but left the `.framework` bundles inside every slice unsigned. An App Store IPA built against it:

```
Python-ios.xcframework-ios.signature   signed=true  isSecureTimestamp=false
_ssl.xcframework-ios.signature         signed=true  isSecureTimestamp=false
_hashlib.xcframework-ios.signature     signed=true  isSecureTimestamp=false
dart_bridge.xcframework-ios.signature  signed=true  isSecureTimestamp=false
```

`signed` flipped as intended — that was #37 working. The receipt cdhashes match the published artifacts byte for byte (`_ssl` → `ddb6c974196b0e16fef3c5e8defb4805b5d344ca`), and the receipt's embedded leaf certificate is our `Apple Distribution: Appveyor Systems Inc. (GXXRQJK434)`, so Xcode was reading our signatures. But `isSecureTimestamp` stayed false despite the outer seals carrying genuine Apple TSA timestamps.

Checked in both a development archive and an App Store export — identical, so the export method wasn't the variable. (Also learned the `Signatures/` folder only travels in App Store–bound IPAs; development and ad-hoc exports omit it, and it lives in the `.xcarchive` in all cases.)

## The control

[krzyzanowskim/OpenSSL](https://github.com/krzyzanowskim/OpenSSL) 3.6.3000 — accepted by Apple's scan per [partout-io/openssl-apple#72](https://github.com/partout-io/openssl-apple/issues/72#issuecomment-3266027136). All ten slices are signed, outer signed last:

```
inner  OpenSSL.framework    Apple Distribution: Goodnotes Limited (C88F57F4TJ)  Timestamp 4:15:36–4:15:45
outer  OpenSSL.xcframework  Apple Distribution: Goodnotes Limited (C88F57F4TJ)  Timestamp 4:15:47
```

Ours: `codesign -dvvv` on any inner framework reported *not signed at all*. That was the only structural difference left.

## The change

`xcf_sign_one` signs each slice's `.framework` first, outer bundle last. **The order is not optional** — the outer seal hashes the bundle contents, so signing an inner framework afterwards would invalidate it, which is the exact failure mode this repo's signing work exists to prevent. No `-i` on the inner bundles: a `.framework` carries a real `CFBundleIdentifier` in its own `Info.plist`.

Verification refactored into `xcf_assert_signature` (verifiable, not ad-hoc, secure timestamp, expected authority, expected team) and applied to every slice framework as well as the outer bundle. An unsigned inner framework now fails the release.

Still no `--deep` — Apple documents it as inappropriate for a distributable signature; signing each slice explicitly gives the same coverage correctly.

**No script outside the shared helper changes.** `sign_darwin_archives.sh` already signs the finished archives through `xcf_sign_one`, and inner `_CodeSignature` directories survive both `xcodebuild -create-xcframework` and the tar round trip (verified).

## dart_bridge 1.7.1

`manifest.json` moves to **1.7.1**, the first dart_bridge release whose framework slices are signed rather than only the outer xcframework.

Both halves have to move together: an IPA that picks up a 1.7.0 dart_bridge alongside inner-signed Python XCFrameworks would still carry one receipt reporting `isSecureTimestamp = false`, which leaves the question unanswered rather than answered. Version bump rather than a re-release, because consumer caches are version-keyed and hold the outer-only-signed 1.7.0 zip.

**Merge order:** dart-bridge#14 → release dart_bridge v1.7.1 → merge this → cut the new date-keyed release here. Merging this first would pin a manifest at a release that does not exist yet.

## Expect a slower signing job

This adds roughly two extra `codesign` invocations per xcframework — about **500 TSA round trips** across the three Python versions, up from ~170. `sign-darwin-artifacts` will take noticeably longer than on 20260729. If it becomes a problem, the fan-out is a one-line change to pipeline per archive.

## Honest caveat

This makes our artifacts structurally identical to one Apple accepts, which is the strongest evidence available. It is **not** proof that `isSecureTimestamp` will flip — the field's semantics are undocumented, and the audited archive contained no signed third-party control to compare against. The definitive test is a TestFlight upload once this, dart-bridge 1.7.1, and the `serious_python` re-pin have all landed.