### PR TITLE
Bump Pythons to 3.12.14/3.13.15/3.14.7, Pyodide 314.0.6, dart_bridge 1.8.0

### DIFF
--- a/.github/workflows/build-python-version.yml
+++ b/.github/workflows/build-python-version.yml
@@ -14,9 +14,9 @@ on:
         required: true
         type: choice
         options:
-          - 3.12.13
-          - 3.13.14
-          - 3.14.6
+          - 3.12.14
+          - 3.13.15
+          - 3.14.7
 
 env:
   PYTHON_VERSION: ${{ inputs.python_version || github.event.inputs.python_version }}

--- a/darwin/ios_patches/3.13/Python.patch
+++ b/darwin/ios_patches/3.13/Python.patch
@@ -7284,7 +7284,7 @@ index 0df4751..cf32adf 100755
  fi
  ac_fn_c_check_func "$LINENO" "sigfillset" "ac_cv_func_sigfillset"
  if test "x$ac_cv_func_sigfillset" = xyes
-@@ -19363,11 +19547,11 @@ fi
+@@ -19376,11 +19560,11 @@ fi
  
  fi
  
@@ -7295,6 +7295,15 @@ index 0df4751..cf32adf 100755
  # raise an error if used at runtime. Force these symbols off.
 -if test "$ac_sys_system" != "iOS" ; then
 +if test "$ac_sys_system" != "iOS" -a "$ac_sys_system" != "tvOS" -a "$ac_sys_system" != "visionOS" -a "$ac_sys_system" != "watchOS" ; then
+   ac_fn_c_check_func "$LINENO" "getentropy" "ac_cv_func_getentropy"
+ if test "x$ac_cv_func_getentropy" = xyes
+ then :
+@@ -19403,7 +19587,7 @@ fi
+ # In addition, macOS introduced dup3 and pipe2 in macOS 27, late in the
+ # lifetime of this version of Python. Rather than adding weaklinking
+ # support for them, just continue to ignore them.
+-if test "$ac_sys_system" != "iOS" -a "$ac_sys_system" != "Darwin"; then
++if test "$ac_sys_system" != "iOS" -a "$ac_sys_system" != "Darwin" -a "$ac_sys_system" != "tvOS" -a "$ac_sys_system" != "visionOS" -a "$ac_sys_system" != "watchOS"; then
    ac_fn_c_check_func "$LINENO" "dup3" "ac_cv_func_dup3"
  if test "x$ac_cv_func_dup3" = xyes
  then :
@@ -7931,7 +7940,7 @@ index a016a43..698553b 100644
    sigfillset siginterrupt sigpending sigrelse sigtimedwait sigwait \
    sigwaitinfo snprintf splice strftime strlcpy strsignal symlinkat sync \
    sysconf tcgetpgrp tcsetpgrp tempnam timegm times tmpfile \
-@@ -5275,14 +5474,22 @@ if test "$MACHDEP" != linux; then
+@@ -5275,20 +5474,28 @@ if test "$MACHDEP" != linux; then
    AC_CHECK_FUNCS([lchmod])
  fi
  
@@ -7942,7 +7951,14 @@ index a016a43..698553b 100644
  # raise an error if used at runtime. Force these symbols off.
 -if test "$ac_sys_system" != "iOS" ; then
 +if test "$ac_sys_system" != "iOS" -a "$ac_sys_system" != "tvOS" -a "$ac_sys_system" != "visionOS" -a "$ac_sys_system" != "watchOS" ; then
-   AC_CHECK_FUNCS([dup3 getentropy getgroups pipe2 system])
+   AC_CHECK_FUNCS([getentropy getgroups system])
+ fi
+ # In addition, macOS introduced dup3 and pipe2 in macOS 27, late in the
+ # lifetime of this version of Python. Rather than adding weaklinking
+ # support for them, just continue to ignore them.
+-if test "$ac_sys_system" != "iOS" -a "$ac_sys_system" != "Darwin"; then
++if test "$ac_sys_system" != "iOS" -a "$ac_sys_system" != "Darwin" -a "$ac_sys_system" != "tvOS" -a "$ac_sys_system" != "visionOS" -a "$ac_sys_system" != "watchOS"; then
+   AC_CHECK_FUNCS([dup3 pipe2])
  fi
  
 +# tvOS/watchOS have some additional methods that can be found, but not used.

--- a/manifest.json
+++ b/manifest.json
@@ -1,27 +1,27 @@
 {
   "default_python_version": "3.14",
-  "dart_bridge_version": "1.7.1",
+  "dart_bridge_version": "1.8.0",
   "pythons": {
     "3.12": {
-      "full_version": "3.12.13",
-      "standalone_release_date": "20260623",
+      "full_version": "3.12.14",
+      "standalone_release_date": "20260901",
       "pyodide_version": "0.27.7",
       "pyodide_platform_tag": "pyodide-2024.0-wasm32",
       "android_abis": ["arm64-v8a", "x86_64", "armeabi-v7a"],
       "prerelease": false
     },
     "3.13": {
-      "full_version": "3.13.14",
-      "standalone_release_date": "20260623",
+      "full_version": "3.13.15",
+      "standalone_release_date": "20260901",
       "pyodide_version": "0.29.4",
       "pyodide_platform_tag": "pyemscripten-2025.0-wasm32",
       "android_abis": ["arm64-v8a", "x86_64", "armeabi-v7a"],
       "prerelease": false
     },
     "3.14": {
-      "full_version": "3.14.6",
-      "standalone_release_date": "20260623",
-      "pyodide_version": "314.0.3",
+      "full_version": "3.14.7",
+      "standalone_release_date": "20260901",
+      "pyodide_version": "314.0.6",
       "pyodide_platform_tag": "pyemscripten-2026.0-wasm32",
       "android_abis": ["arm64-v8a", "x86_64", "armeabi-v7a"],
       "prerelease": false


### PR DESCRIPTION
## Manifest

| | before | after |
|---|---|---|
| 3.12 | 3.12.13 | **3.12.14** |
| 3.13 | 3.13.14 | **3.13.15** |
| 3.14 | 3.14.6 | **3.14.7** |
| `standalone_release_date` (all three) | 20260623 | **20260901** |
| 3.14 `pyodide_version` | 314.0.3 | **314.0.6** |
| `dart_bridge_version` | 1.7.1 | **1.8.0** |

`20260901` is the newest python-build-standalone release and the first that carries all three micros (`20260825` has them too). Pyodide `0.29.4` (3.13) and `0.27.7` (3.12) are already the newest on their lines, so they stay put — only the 3.14 line moved.

The `workflow_dispatch` choice list in `build-python-version.yml` is the only other place full versions are spelled out, so it moves with the manifest. (The remaining `3.14.6` hits in the repo are all illustrative comments.)

## Refresh the vendored 3.13 iOS patch for 3.13.15

3.13.15 back-ported the macOS 27 `dup3`/`pipe2` change from 3.14, splitting

```
if test "$ac_sys_system" != "iOS" ; then
  AC_CHECK_FUNCS([dup3 getentropy getgroups pipe2 system])
fi
```

into a `getentropy getgroups system` check gated on iOS and a separate `dup3 pipe2` check gated on iOS **and** Darwin. Our back-port widens that gate to the other Apple platforms, so its hunk no longer applied — one hunk failed in `configure.ac`, one in `configure` (42/43 and 35/36 applying). The 3.12 patch is unaffected; 3.12.14 does not carry the change.

Both gates now get the tvOS/visionOS/watchOS arms. That preserves the patch's intent: `dup3` and `pipe2` were in the widened set before the split, so leaving them out of it would have quietly re-enabled two symbols on those platforms. Nothing here builds tvOS/visionOS/watchOS, so it is inert for our matrix — it just keeps the vendored patch faithful to the beeware back-port it came from.

## Verification

Extracted the pristine 3.12.14 and 3.13.15 tarballs from python.org and applied each vendored patch with `patch -p1`, per `darwin/ios_patches/README.md`:

- **zero rejects**, no offsets, no fuzz on either version
- confirmed the pre-bump 3.13.14 still applied cleanly, so the two failures were genuinely micro-bump drift and not a pre-existing break
- the merged `configure` and `configure.ac` agree with each other on both gates

Upstream availability confirmed for every version bumped here (astral-sh/python-build-standalone `20260901`, pyodide/pyodide `314.0.6`, flet-dev/dart-bridge `v1.8.0`).

CI on this PR exercises the full matrix without publishing a release.