### PR TITLE
Bump dart_bridge to 1.9.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "default_python_version": "3.14",
-  "dart_bridge_version": "1.8.0",
+  "dart_bridge_version": "1.9.0",
   "pythons": {
     "3.12": {
       "full_version": "3.12.14",


### PR DESCRIPTION
Bumps `manifest.json` to `dart_bridge` **1.9.0**. No Python versions change.

## Why

dart_bridge 1.9.0 adds `serious_python_hard_exit`, which terminates the process without running `atexit` handlers or C++ static destructors ([flet-dev/dart-bridge#20](https://github.com/flet-dev/dart-bridge/pull/20)).

Embedders were seeing a `SIGSEGV` on exit from apps that had otherwise finished their work. The interpreter runs on a detached thread that may still be executing native extension code when the host quits, and a normal `exit()` runs `__cxa_finalize`, destroying the C++ statics inside every loaded extension module out from under it. The reported case died in matplotlib's `ft2font` looking up a pybind11 type-caster map that had just been destructed; `numpy`, `Pillow` and Flutter's own Skia statics are torn down by the same pass.

## Release chain

`manifest.json` is the single source of truth and is published as a release asset, so a re-release is what actually propagates the new bridge version:

1. **dart-bridge 1.9.0** released - [flet-dev/dart-bridge#20](https://github.com/flet-dev/dart-bridge/pull/20)
2. **this PR**, then a `Build Python Packages` run with a `release_date` to cut the dated release
3. **serious_python** regenerates its version tables against that release (`dart run serious_python:gen_version_tables --release-date <YYYYMMDD>`), which is what moves `dart_bridge_version` and `python_build_release_date` in the generated `python_versions.properties` / `python_versions.dart`
4. **flet** bumps its `serious_python` pin

Nothing downstream can move until the release in step 2 exists, since the generator fetches the manifest from the python-build release by date.